### PR TITLE
Improve shorthand logic

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -5,4 +5,6 @@
 .github/
 automate/
 target/
+shorthand/
+Cargo.toml
 **/*.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["./example/native/hub", "./shorthand"]
+members = ["./example/native/*", "./shorthand"]
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,3 @@
 [workspace]
-members = ["./example/native/hub"]
-exclude = ["./shorthand"]
+members = ["./example/native/hub", "./shorthand"]
 resolver = "2"

--- a/shorthand/Cargo.toml
+++ b/shorthand/Cargo.toml
@@ -5,6 +5,3 @@ edition = "2021"
 license = "MIT"
 description = "Rust as your Flutter backend, Flutter as your Rust frontend"
 repository = "https://github.com/cunarist/rust-in-flutter"
-
-[dependencies]
-which = "4.4.2"

--- a/shorthand/README.md
+++ b/shorthand/README.md
@@ -5,3 +5,5 @@
 ![preview](https://github.com/cunarist/rust-in-flutter/assets/66480156/be85cf04-2240-497f-8d0d-803c40536d8e)
 
 RIFS is a command-line tool for simplifying the use of the Rust-In-Flutter framework. For detailed information on how to use this framework, please refer to the [documentation](https://docs.cunarist.com/rust-in-flutter/).
+
+Explore the web-based [demo](https://rif-example.cunarist.com/) to enjoy the seamless and enjoyable experience created by the fusion of Flutter and Rust.

--- a/shorthand/src/main.rs
+++ b/shorthand/src/main.rs
@@ -6,8 +6,12 @@ fn main() {
     let dart_command_args: Vec<String> = env::args().skip(1).collect();
 
     // Build the command to run the Dart script
-    let dart_path = which::which("dart").unwrap(); // https://github.com/rust-lang/rust/issues/37519
-    let mut command = Command::new(dart_path);
+    #[cfg(target_family = "windows")]
+    let mut command = Command::new("dart.bat");
+    #[cfg(target_family = "unix")]
+    let mut command = Command::new("dart");
+    #[cfg(target_family = "wasm")]
+    let mut command = Command::new("dart");
     command.args(["run", "rust_in_flutter"]);
     command.args(&dart_command_args);
 


### PR DESCRIPTION
## Changes

Improve workspace and shorthand crate. Also, crate `which` is now removed from dependencies.

## Before Committing

_Please make sure that you've formatted the files._

```
dart format .
cargo clippy --fix
```
