### PR TITLE
Provide `debug_print!` macro and report Rust panics to Flutter

### DIFF
--- a/automate/__main__.py
+++ b/automate/__main__.py
@@ -81,6 +81,9 @@ elif sys.argv[1] == "bridge-gen":
     search_string = "@protected"
     replace_string = ""
     replace_string_in_files(directory_path, search_string, replace_string)
+    search_string = "@internal"
+    replace_string = ""
+    replace_string_in_files(directory_path, search_string, replace_string)
 
     directory_path = "./example/native/hub/src/bridge"
     search_string = "flutter_rust_bridge::"

--- a/documentation/docs/writing-code.md
+++ b/documentation/docs/writing-code.md
@@ -290,3 +290,15 @@ This is a bytes array created by Protobuf serialization. Note that it is not rec
 ### Field `blob`
 
 This is also a bytes array intended to contain large data up to a few gigabytes. You can send any kind of binary as you wish such as a high-resolution image or some kind of file data. Sending a blob is a zero-copy operation, which means no memory copy is involved. This field is optional and can be `null` or `None`.
+
+## 🖨️ The `debug_print!` Macro
+
+You might be used to `println!` macro in Rust. However, using that macro isn't a very good idea in our apps made with Flutter and Rust because `println!` outputs cannot be seen on the web and mobile emulators.
+
+The `debug_print!` macro is better than `println!` in that it only works in debug mode, resulting in a smaller and cleaner release binary.
+
+When writing Rust code in the `hub` crate, you can simply print your debug message like below. Once you use this macro, Flutter will handle the rest.
+
+```rust
+crate::debug_print!("My object is {:?}", my_object);
+```

--- a/documentation/docs/writing-code.md
+++ b/documentation/docs/writing-code.md
@@ -297,7 +297,7 @@ You might be used to `println!` macro in Rust. However, using that macro isn't a
 
 The `debug_print!` macro is better than `println!` in that it only works in debug mode, resulting in a smaller and cleaner release binary.
 
-When writing Rust code in the `hub` crate, you can simply print your debug message like below. Once you use this macro, Flutter will handle the rest.
+When writing Rust code in the `hub` crate, you can simply print your debug message like below. Once you use this macro, Flutter will take care of the rest.
 
 ```rust
 crate::debug_print!("My object is {:?}", my_object);

--- a/example/native/hub/Cargo.toml
+++ b/example/native/hub/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 [lib]
 # `lib` is required for non-library targets,
 # such as tests and benchmarks.
+# `cdylib` is for Linux, Android, Windows, and web.
 # `staticlib` is for iOS and macOS.
-# `cdylib` is for all other platforms.
 crate-type = ["lib", "cdylib", "staticlib"]
 
 # These are dependencies for non-web platforms.
@@ -32,7 +32,6 @@ web-sys = { version = "0.3.64", features = [
     "Worker",
     "Url",
     "BroadcastChannel",
-    "console",
 ] }
 gloo-timers = { version = "0.3.0", features = ["futures"] }
 

--- a/example/native/hub/src/bridge/api.rs
+++ b/example/native/hub/src/bridge/api.rs
@@ -71,6 +71,7 @@ type SharedCell<T> = Arc<Mutex<Cell<T>>>;
 
 type RustSignalStream = StreamSink<RustSignal>;
 type RustResponseStream = StreamSink<RustResponseUnique>;
+type RustPrintStream = StreamSink<String>;
 type RustRequestSender = Sender<RustRequestUnique>;
 type RustRequestReceiver = Receiver<RustRequestUnique>;
 
@@ -85,6 +86,7 @@ thread_local! {
 thread_local! {
     pub static SIGNAL_STREAM: Cell<RustSignalStream> = RefCell::new(None);
     pub static RESPONSE_STREAM: Cell<RustResponseStream> = RefCell::new(None);
+    pub static PRINT_STREAM: Cell<RustPrintStream> = RefCell::new(None);
     pub static RESPONSE_SENDER: Cell<RustResponseUnique> = RefCell::new(None);
 }
 
@@ -94,6 +96,8 @@ lazy_static! {
     pub static ref SIGNAL_STREAM_SHARED: SharedCell<RustSignalStream> =
         Arc::new(Mutex::new(RefCell::new(None)));
     pub static ref RESPONSE_STREAM_SHARED: SharedCell<RustResponseStream> =
+        Arc::new(Mutex::new(RefCell::new(None)));
+    pub static ref PRINT_STREAM_SHARED: SharedCell<RustPrintStream> =
         Arc::new(Mutex::new(RefCell::new(None)));
     pub static ref REQUST_RECEIVER_SHARED: SharedCell<RustRequestReceiver> =
         Arc::new(Mutex::new(RefCell::new(None)));
@@ -111,10 +115,16 @@ pub fn prepare_rust_signal_stream(signal_stream: StreamSink<RustSignal>) {
     cell.replace(Some(signal_stream));
 }
 
-/// Returns a stream object in Dart that returns responses from Rust.
+/// Returns a stream object in Dart that gives responses from Rust.
 pub fn prepare_rust_response_stream(response_stream: StreamSink<RustResponseUnique>) {
     let cell = RESPONSE_STREAM_SHARED.lock().unwrap();
     cell.replace(Some(response_stream));
+}
+
+/// Returns a stream object in Dart that gives strings to print from Rust.
+pub fn prepare_rust_print_stream(print_stream: StreamSink<String>) {
+    let cell = PRINT_STREAM_SHARED.lock().unwrap();
+    cell.replace(Some(print_stream));
 }
 
 /// Prepare channels that are used in the Rust world.

--- a/example/native/hub/src/bridge/api.rs
+++ b/example/native/hub/src/bridge/api.rs
@@ -154,6 +154,10 @@ pub fn check_rust_streams() -> bool {
 
 /// Start the main function of Rust.
 pub fn start_rust_logic() {
+    #[cfg(debug_assertions)]
+    std::panic::set_hook(Box::new(|panic_info| {
+        crate::debug_print!("A panic occurred in Rust.\n{}", panic_info);
+    }));
     #[cfg(not(target_family = "wasm"))]
     {
         TOKIO_RUNTIME.with(move |inner| {

--- a/example/native/hub/src/bridge/bridge_generated.io.rs
+++ b/example/native/hub/src/bridge/bridge_generated.io.rs
@@ -12,6 +12,11 @@ pub extern "C" fn wire_prepare_rust_response_stream(port_: i64) {
 }
 
 #[no_mangle]
+pub extern "C" fn wire_prepare_rust_print_stream(port_: i64) {
+    wire_prepare_rust_print_stream_impl(port_)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_prepare_channels(port_: i64) {
     wire_prepare_channels_impl(port_)
 }

--- a/example/native/hub/src/bridge/bridge_generated.rs
+++ b/example/native/hub/src/bridge/bridge_generated.rs
@@ -54,6 +54,22 @@ fn wire_prepare_rust_response_stream_impl(port_: MessagePort) {
         },
     )
 }
+fn wire_prepare_rust_print_stream_impl(port_: MessagePort) {
+    BRIDGE_HANDLER.wrap::<_, _, _, ()>(
+        WrapInfo {
+            debug_name: "prepare_rust_print_stream",
+            port: Some(port_),
+            mode: FfiCallMode::Stream,
+        },
+        move || {
+            move |task_callback| {
+                Ok(prepare_rust_print_stream(
+                    task_callback.stream_sink::<_, String>(),
+                ))
+            }
+        },
+    )
+}
 fn wire_prepare_channels_impl(port_: MessagePort) {
     BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {

--- a/example/native/hub/src/bridge/bridge_generated.web.rs
+++ b/example/native/hub/src/bridge/bridge_generated.web.rs
@@ -12,6 +12,11 @@ pub fn wire_prepare_rust_response_stream(port_: MessagePort) {
 }
 
 #[wasm_bindgen]
+pub fn wire_prepare_rust_print_stream(port_: MessagePort) {
+    wire_prepare_rust_print_stream_impl(port_)
+}
+
+#[wasm_bindgen]
 pub fn wire_prepare_channels(port_: MessagePort) {
     wire_prepare_channels_impl(port_)
 }

--- a/example/native/hub/src/sample_functions.rs
+++ b/example/native/hub/src/sample_functions.rs
@@ -34,6 +34,7 @@ pub async fn handle_counter_number(rust_request: RustRequest) -> RustResponse {
             // Decode raw bytes into a Rust message object.
             let message_bytes = rust_request.message.unwrap();
             let request_message = ReadRequest::decode(message_bytes.as_slice()).unwrap();
+            crate::debug_print!("{}", request_message.letter);
 
             // Perform a simple calculation.
             let after_value: i32 = sample_crate::add_seven(request_message.before_number);

--- a/example/native/hub/src/web_alias.rs
+++ b/example/native/hub/src/web_alias.rs
@@ -55,16 +55,3 @@ pub async fn sleep(duration: std::time::Duration) {
     #[cfg(target_family = "wasm")]
     gloo_timers::future::sleep(duration).await;
 }
-
-// On the web, the `println!` macro does not print to the browser console.
-// Crate `web_sys` does something exactly like `console.log()` in JavaScript.
-
-#[macro_export]
-#[cfg(target_family = "wasm")]
-macro_rules! print {
-    ( $( $t:tt )* ) => {
-        web_sys::console::log_1(&format!( $( $t )* ).into());
-    }
-}
-#[cfg(not(target_family = "wasm"))]
-pub(crate) use println as print;

--- a/lib/rust_in_flutter.dart
+++ b/lib/rust_in_flutter.dart
@@ -5,6 +5,7 @@
 import 'dart:math';
 import 'dart:async';
 import 'src/exports.dart';
+import 'package:flutter/foundation.dart';
 
 export 'src/exports.dart' show RustOperation;
 export 'src/exports.dart' show RustRequest;
@@ -32,6 +33,12 @@ class RustInFlutter {
     rustResponseStream.listen((responseUnique) {
       _responseBroadcaster.add(responseUnique);
     });
+    if (kDebugMode) {
+      final rustPrintStream = api.prepareRustPrintStream();
+      rustPrintStream.listen((printContent) {
+        debugPrint(printContent);
+      });
+    }
     while (!(await api.checkRustStreams())) {}
     api.startRustLogic();
   }

--- a/lib/src/bridge_definitions.dart
+++ b/lib/src/bridge_definitions.dart
@@ -15,10 +15,15 @@ abstract class Bridge {
 
   FlutterRustBridgeTaskConstMeta get kPrepareRustSignalStreamConstMeta;
 
-  /// Returns a stream object in Dart that returns responses from Rust.
+  /// Returns a stream object in Dart that gives responses from Rust.
   Stream<RustResponseUnique> prepareRustResponseStream({dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kPrepareRustResponseStreamConstMeta;
+
+  /// Returns a stream object in Dart that gives strings to print from Rust.
+  Stream<String> prepareRustPrintStream({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kPrepareRustPrintStreamConstMeta;
 
   /// Prepare channels that are used in the Rust world.
   Future<void> prepareChannels({dynamic hint});

--- a/lib/src/bridge_generated.dart
+++ b/lib/src/bridge_generated.dart
@@ -53,6 +53,22 @@ class BridgeImpl implements Bridge {
         argNames: [],
       );
 
+  Stream<String> prepareRustPrintStream({dynamic hint}) {
+    return _platform.executeStream(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_prepare_rust_print_stream(port_),
+      parseSuccessData: _wire2api_String,
+      constMeta: kPrepareRustPrintStreamConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kPrepareRustPrintStreamConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
+        debugName: "prepare_rust_print_stream",
+        argNames: [],
+      );
+
   Future<void> prepareChannels({dynamic hint}) {
     return _platform.executeNormal(FlutterRustBridgeTask(
       callFfi: (port_) => _platform.inner.wire_prepare_channels(port_),
@@ -124,6 +140,10 @@ class BridgeImpl implements Bridge {
     _platform.dispose();
   }
 // Section: wire2api
+
+  String _wire2api_String(dynamic raw) {
+    return raw as String;
+  }
 
   bool _wire2api_bool(dynamic raw) {
     return raw as bool;

--- a/lib/src/bridge_generated.io.dart
+++ b/lib/src/bridge_generated.io.dart
@@ -193,6 +193,20 @@ class BridgeWire implements FlutterRustBridgeWireBase {
   late final _wire_prepare_rust_response_stream =
       _wire_prepare_rust_response_streamPtr.asFunction<void Function(int)>();
 
+  void wire_prepare_rust_print_stream(
+    int port_,
+  ) {
+    return _wire_prepare_rust_print_stream(
+      port_,
+    );
+  }
+
+  late final _wire_prepare_rust_print_streamPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_prepare_rust_print_stream');
+  late final _wire_prepare_rust_print_stream =
+      _wire_prepare_rust_print_streamPtr.asFunction<void Function(int)>();
+
   void wire_prepare_channels(
     int port_,
   ) {
@@ -328,4 +342,4 @@ typedef DartPostCObjectFnType = ffi.Pointer<
         ffi.Bool Function(DartPort port_id, ffi.Pointer<ffi.Void> message)>>;
 typedef DartPort = ffi.Int64;
 
-const int ID = 2;
+const int ID = 3;

--- a/lib/src/bridge_generated.web.dart
+++ b/lib/src/bridge_generated.web.dart
@@ -63,6 +63,9 @@ class BridgeWasmModule implements WasmModule {
   external dynamic /* void */ wire_prepare_rust_response_stream(
       NativePortType port_);
 
+  external dynamic /* void */ wire_prepare_rust_print_stream(
+      NativePortType port_);
+
   external dynamic /* void */ wire_prepare_channels(NativePortType port_);
 
   external dynamic /* void */ wire_check_rust_streams(NativePortType port_);
@@ -84,6 +87,9 @@ class BridgeWire extends FlutterRustBridgeWasmWireBase<BridgeWasmModule> {
 
   void wire_prepare_rust_response_stream(NativePortType port_) =>
       wasmModule.wire_prepare_rust_response_stream(port_);
+
+  void wire_prepare_rust_print_stream(NativePortType port_) =>
+      wasmModule.wire_prepare_rust_print_stream(port_);
 
   void wire_prepare_channels(NativePortType port_) =>
       wasmModule.wire_prepare_channels(port_);


### PR DESCRIPTION
## Changes

Until now, there was no reliable way to print debug messages on all environments. There was `crate::print!`, but this could not work in mobile emulators. Also, various panics were not visible.

This PR improves debugging experience.

## Before Committing

_Please make sure that you've formatted the files._

```
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
