### PR TITLE
Show backtrace on Rust panic

### DIFF
--- a/example/native/hub/Cargo.toml
+++ b/example/native/hub/Cargo.toml
@@ -18,6 +18,7 @@ dart-sys = { version = "4.0.2" }
 allo-isolate = { version = "0.1.20", features = ["zero-copy"] }
 tokio = { version = "1.28.2", features = ["rt-multi-thread", "time"] }
 os-thread-local = "0.1.3"
+backtrace = "0.3.69"
 
 # These are dependencies for the web.
 [target.'cfg(target_family = "wasm")'.dependencies]

--- a/example/native/hub/src/bridge/api.rs
+++ b/example/native/hub/src/bridge/api.rs
@@ -168,15 +168,17 @@ pub fn start_rust_logic() {
             let mut frames_filtered = Vec::new();
             backtrace::trace(|frame| {
                 // Filter some backtrace frames
-                // as those from infrastructure crates are not needed.
+                // as those from infrastructure functions are not needed.
                 let mut should_keep_tracing = true;
                 backtrace::resolve_frame(frame, |symbol| {
                     if let Some(symbol_name) = symbol.name() {
                         let name = symbol_name.to_string();
-                        if name.starts_with("backtrace::") {
+                        let name_trimmed = name.trim_start_matches('_');
+                        if name_trimmed.starts_with("rust_begin_unwind") {
+                            frames_filtered.clear();
                             return;
                         }
-                        if name.starts_with("tokio::") {
+                        if name_trimmed.starts_with("rust_try") {
                             should_keep_tracing = false;
                             return;
                         }

--- a/example/native/hub/src/bridge/api.rs
+++ b/example/native/hub/src/bridge/api.rs
@@ -161,12 +161,13 @@ pub fn check_rust_streams() -> bool {
 
 /// Start the main function of Rust.
 pub fn start_rust_logic() {
-    #[cfg(debug_assertions)]
-    std::panic::set_hook(Box::new(|panic_info| {
-        crate::debug_print!("A panic occurred in Rust.\n{}", panic_info);
-    }));
     #[cfg(not(target_family = "wasm"))]
     {
+        #[cfg(debug_assertions)]
+        std::panic::set_hook(Box::new(|panic_info| {
+            let backtrace = backtrace::Backtrace::new();
+            crate::debug_print!("A panic occurred in Rust.\n{}\n{:?}", panic_info, backtrace);
+        }));
         TOKIO_RUNTIME.with(move |inner| {
             let tokio_runtime = tokio::runtime::Builder::new_multi_thread()
                 .enable_all()

--- a/lib/rust_in_flutter.dart
+++ b/lib/rust_in_flutter.dart
@@ -2,8 +2,8 @@
 /// More specifically, sending requests to Rust and
 /// receiving stream signals from Rust are possible.
 
-import 'dart:math';
 import 'dart:async';
+import 'dart:math';
 import 'src/exports.dart';
 import 'package:flutter/foundation.dart';
 
@@ -36,7 +36,7 @@ class RustInFlutter {
     if (kDebugMode) {
       final rustReportStream = api.prepareRustReportStream();
       rustReportStream.listen((rustReport) {
-        debugPrint(rustReport);
+        print(rustReport);
       });
     }
     while (!(await api.checkRustStreams())) {}
@@ -79,12 +79,13 @@ Future<RustResponse> requestToRust(RustRequest rustRequest) async {
 }
 
 class _IdGenerator {
-  int _counter = -pow(2, 31).toInt();
   final _maxLimit = pow(2, 31).toInt() - 1;
+  final _minLimit = -pow(2, 31).toInt();
+  int _counter = 0;
   int generateId() {
     final id = _counter;
     final increased = _counter + 1;
-    _counter = increased <= _maxLimit ? increased : -pow(2, 31).toInt();
+    _counter = increased <= _maxLimit ? increased : _minLimit;
     return id;
   }
 }


### PR DESCRIPTION
## Changes

4.6.0 provided CLI output on panic, but the Rust backtrace wasn't shown at all. This PR adds backtraces to the CLI output on Rust panic.

Output:

<img width="716" alt="image" src="https://github.com/cunarist/rust-in-flutter/assets/66480156/2e64a099-5b9a-44f3-be15-8500a3d677c9">

The code(sligtly modified `./native/hub/sample_functions.rs`):

```rust
pub async fn handle_counter_number(rust_request: RustRequest) -> RustResponse {
    use crate::messages::counter_number::{ReadRequest, ReadResponse};
    // We import message structs in this handler function
    // because schema will differ by Rust resource.
    foo().await;

    // match rust_request.operation {
    //     RustOperation::Create => RustResponse::default(),
    //     RustOperation::Read => {
    //         // Decode raw bytes into a Rust message object.
    //         let message_bytes = rust_request.message.unwrap();
    //         let request_message = ReadRequest::decode(message_bytes.as_slice()).unwrap();
    //         crate::debug_print!("{}", request_message.letter);

    //         // Perform a simple calculation.
    //         let after_value: i32 = sample_crate::add_seven(request_message.before_number);

    //         // Return the response that will be sent to Dart.
    //         let response_message = ReadResponse {
    //             after_number: after_value,
    //             dummy_one: request_message.dummy_one,
    //             dummy_two: request_message.dummy_two,
    //             dummy_three: request_message.dummy_three,
    //         };
    //         RustResponse {
    //             successful: true,
    //             message: Some(response_message.encode_to_vec()),
    //             blob: None,
    //         }
    //     }
    //     RustOperation::Update => RustResponse::default(),
    //     RustOperation::Delete => RustResponse::default(),
    // }
}

async fn foo() {
    bar();
}

fn bar() {
    panic!("AN INTENTIONAL PANIC FOR RIF DEMONSTRATION");
}
```

## Before Committing

_Please make sure that you've formatted the files._

```
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
