### PR TITLE
Provide multicore parallelism with `spawn_blocking`

### DIFF
--- a/example/native/hub/Cargo.toml
+++ b/example/native/hub/Cargo.toml
@@ -34,6 +34,7 @@ web-sys = { version = "0.3.64", features = [
     "Url",
     "BroadcastChannel",
 ] }
+async_wasm_task = "0.2.0"
 
 [dependencies]
 bytemuck = "1.11.0"

--- a/example/native/hub/Cargo.toml
+++ b/example/native/hub/Cargo.toml
@@ -34,7 +34,7 @@ web-sys = { version = "0.3.64", features = [
     "Url",
     "BroadcastChannel",
 ] }
-async_wasm_task = "0.2.0"
+async_wasm_task = "0.2.2"
 
 [dependencies]
 bytemuck = "1.11.0"

--- a/example/native/hub/src/bridge/bridge_engine/wasm_bindgen_src/worker.rs
+++ b/example/native/hub/src/bridge/bridge_engine/wasm_bindgen_src/worker.rs
@@ -21,27 +21,29 @@ pub fn replace_worker() {
 
 fn create_worker() -> Worker {
     let script = format!(
-        "importScripts('{}');
-            onmessage = event => {{
-                let init = wasm_bindgen(...event.data).catch(err => {{
-                    setTimeout(() => {{ throw err }})
-                    throw err
-                }})
-                onmessage = async event => {{
-                    await init
-                    let [payload, ...transfer] = event.data
-                    try {{
-                        wasm_bindgen.receive_transfer_closure(payload, transfer)
-                    }} catch (err) {{
-                        if (transfer[0] && typeof transfer[0].postMessage === 'function') {{
-                            transfer[0].postMessage([1, 'ABORT', err.toString(), err.stack])
-                        }}
-                        setTimeout(() => {{ throw err }})
-                        postMessage(null)
-                        throw err
+        "
+        importScripts('{}');
+        onmessage = event => {{
+            let init = wasm_bindgen(...event.data).catch(err => {{
+                setTimeout(() => {{ throw err }})
+                throw err
+            }})
+            onmessage = async event => {{
+                await init
+                let [payload, ...transfer] = event.data
+                try {{
+                    wasm_bindgen.receive_transfer_closure(payload, transfer)
+                }} catch (err) {{
+                    if (transfer[0] && typeof transfer[0].postMessage === 'function') {{
+                        transfer[0].postMessage([1, 'ABORT', err.toString(), err.stack])
                     }}
+                    setTimeout(() => {{ throw err }})
+                    postMessage(null)
+                    throw err
                 }}
-            }}",
+            }}
+        }}
+        ",
         script_path().unwrap()
     );
     let blob = Blob::new_with_blob_sequence_and_options(

--- a/example/native/hub/src/sample_functions.rs
+++ b/example/native/hub/src/sample_functions.rs
@@ -134,26 +134,62 @@ pub async fn run_debug_tests() {
     };
     tokio::join!(join_first, join_second, join_third);
 
-    // Avoid blocking the async event loop.
-    let start_time = sample_crate::get_current_time();
+    // Avoid blocking the async event loop by yielding.
     let mut last_time = sample_crate::get_current_time();
     let mut count = 0u64;
+    let mut steps_finished = 0;
     loop {
         count += 1;
         if count % 10000 == 0 {
             crate::yield_now().await;
             let time_passed = sample_crate::get_current_time() - last_time;
-            let total_time_passed = sample_crate::get_current_time() - start_time;
-            if total_time_passed.num_milliseconds() > 10000 {
-                crate::debug_print!("Counting done with {count}");
-                break;
-            } else if time_passed.num_milliseconds() > 1000 {
+            if time_passed.num_milliseconds() > 1000 {
                 crate::debug_print!("Counted to {count}, yielding regularly.");
                 last_time = sample_crate::get_current_time();
+                steps_finished += 1;
+                if steps_finished == 10 {
+                    break;
+                }
             }
         }
     }
 
+    // Test `spawn_blocking` with multicore parallelization.
+    let mut join_handles = Vec::new();
+    let chunk_size = 10_i32.pow(6);
+    for level in 0..10 {
+        let join_handle = crate::spawn_blocking(move || {
+            let mut prime_count = 0;
+            let count_from = level * chunk_size + 1;
+            let count_to = (level + 1) * chunk_size;
+            for number in count_from..=count_to {
+                let mut is_prime = true;
+                let square_root = (number as f64).sqrt() as i32;
+                if number <= 1 {
+                    is_prime = false;
+                } else {
+                    let mut i = 2;
+                    while i <= square_root {
+                        if number % i == 0 {
+                            is_prime = false;
+                            break;
+                        }
+                        i += 1;
+                    }
+                }
+                if is_prime {
+                    prime_count += 1;
+                }
+            }
+            format!("There are {prime_count} primes from {count_from} to {count_to}.")
+        });
+        join_handles.push(join_handle);
+    }
+    for join_handle in join_handles {
+        let text = join_handle.await.unwrap();
+        crate::debug_print!("{text}");
+    }
+
     crate::debug_print!("Debug tests completed!");
-    panic!("This is an intentional panic that comes after debug tests.");
+    panic!("INTENTIONAL DEBUG PANIC");
 }

--- a/example/native/hub/src/sample_functions.rs
+++ b/example/native/hub/src/sample_functions.rs
@@ -70,19 +70,23 @@ pub async fn stream_mandelbrot() {
             scale = 1.0
         };
 
-        let calculated = sample_crate::mandelbrot(
-            sample_crate::Size {
-                width: 256,
-                height: 256,
-            },
-            sample_crate::Point {
-                x: 0.360,
-                y: -0.641,
-            },
-            scale,
-            4,
-        );
-
+        // Calculate the mandelbrot image
+        // parallelly in a separate thread pool.
+        let join_handle = crate::spawn_blocking(move || {
+            sample_crate::mandelbrot(
+                sample_crate::Size {
+                    width: 256,
+                    height: 256,
+                },
+                sample_crate::Point {
+                    x: 0.360,
+                    y: -0.641,
+                },
+                scale,
+                4,
+            )
+        });
+        let calculated = join_handle.await.unwrap();
         if let Some(mandelbrot) = calculated {
             // Stream the signal to Dart.
             let signal_message = StateSignal {

--- a/example/native/hub/src/web_alias.rs
+++ b/example/native/hub/src/web_alias.rs
@@ -44,8 +44,7 @@ where
     F: std::future::Future<Output = T> + Send + 'static,
     T: Send + 'static,
 {
-    let join_handle = tokio::task::spawn(future);
-    join_handle
+    tokio::task::spawn(future)
 }
 #[cfg(target_family = "wasm")]
 pub(crate) fn spawn<F, T>(future: F) -> async_wasm_task::JoinHandle<T>
@@ -53,8 +52,7 @@ where
     F: std::future::Future<Output = T> + 'static,
     T: 'static,
 {
-    let join_handle = async_wasm_task::spawn(future);
-    join_handle
+    async_wasm_task::spawn(future)
 }
 
 // Sometimes, running CPU-intensive blocking tasks is necessary.
@@ -69,8 +67,7 @@ where
     C: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
 {
-    let join_handle = tokio::task::spawn_blocking(callable);
-    join_handle
+    tokio::task::spawn_blocking(callable)
 }
 #[cfg(target_family = "wasm")]
 pub(crate) fn spawn_blocking<C, T>(callable: C) -> async_wasm_task::JoinHandle<T>
@@ -78,8 +75,7 @@ where
     C: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
 {
-    let join_handle = async_wasm_task::spawn_blocking(callable);
-    join_handle
+    async_wasm_task::spawn_blocking(callable)
 }
 
 // To avoid blocking inside a long-running function,

--- a/example/native/sample_crate/src/mandelbrot.rs
+++ b/example/native/sample_crate/src/mandelbrot.rs
@@ -162,20 +162,16 @@ pub fn mandelbrot(
 
     let mut pixels = vec![0; bounds.0 * bounds.1];
     let band_rows = bounds.1 / (num_threads as usize) + 1;
-    let mut bands = pixels.chunks_mut(band_rows * bounds.0).enumerate();
+    let bands = pixels.chunks_mut(band_rows * bounds.0).enumerate();
 
-    loop {
-        if let Some((i, band)) = bands.next() {
-            let top = band_rows * i;
-            let height = band.len() / bounds.0;
-            let band_bounds = (bounds.0, height);
-            let band_upper_left = pixel_to_point(bounds, (0, top), upper_left, lower_right);
-            let band_lower_right =
-                pixel_to_point(bounds, (bounds.0, top + height), upper_left, lower_right);
-            render(band, band_bounds, band_upper_left, band_lower_right);
-        } else {
-            break;
-        }
+    for (i, band) in bands {
+        let top = band_rows * i;
+        let height = band.len() / bounds.0;
+        let band_bounds = (bounds.0, height);
+        let band_upper_left = pixel_to_point(bounds, (0, top), upper_left, lower_right);
+        let band_lower_right =
+            pixel_to_point(bounds, (bounds.0, top + height), upper_left, lower_right);
+        render(band, band_bounds, band_upper_left, band_lower_right);
     }
 
     write_image(&colorize(&pixels), bounds)


### PR DESCRIPTION
## Changes

This not only works on native platforms, but also on the web, utilizing 'web worker's.

## Before Committing

_Please make sure that you've formatted the files._

```
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
