### PR TITLE
Fix automated publishing

### DIFF
--- a/.github/workflows/publication.yaml
+++ b/.github/workflows/publication.yaml
@@ -1,22 +1,27 @@
 name: publication
 
+# With default Git settings, Unix-like systems use LF (`\n`) for new lines,
+# while Windows uses CRLF (`\r\n`) in local repositories.
+# This default Git behavior is not ideal for a cross-platform project like Rinf.
+# Also, the file permission system on Windows is not compatible with unix-like OS.
+
+# If you publish the packages on Windows with `dart pub publish`
+# script files are very likely to produce error on unix-like OS.
+# This issue has already been observed with `.sh` files.
+# That's why we use this manually-triggered Ubuntu workflow to publish packages.
+
 on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*" # Should match the tag pattern set on `pub.dev`.
   workflow_dispatch:
 
 jobs:
   upload:
-    name: upload
+    name: upload-all
     runs-on: ubuntu-latest
-
-    # With default Git settings, Unix-like systems use LF (`\n`) for new lines,
-    # while Windows uses CRLF (`\r\n`) in local repositories.
-    # This default Git behavior is not ideal for a cross-platform project like Rinf.
-    # Also, the file permission system on Windows is not compatible with unix-like OS.
-
-    # If you publish the packages on Windows with `dart pub publish`
-    # script files are very likely to produce error on unix-like OS.
-    # This issue has already been observed with `.sh` files.
-    # That's why we use this manually-triggered Ubuntu workflow to publish packages.
+    permissions:
+      id-token: write # Required for authentication using OIDC for `pub.dev`.
 
     steps:
       - name: Checkout repository
@@ -30,6 +35,8 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      # https://dart.dev/tools/pub/automated-publishing
+
       - name: Check the Flutter FFI plugin
         working-directory: flutter_ffi_plugin/
         run: dart pub publish --dry-run
@@ -38,10 +45,15 @@ jobs:
         working-directory: flutter_ffi_plugin/
         run: dart pub publish --force
 
+      # Save the `crates.io` API token at
+      # `GitHub repo - Settings - Security - Secrets and variables - Actions`.
+
       - name: Check the Rust crate
         working-directory: rust_crate/
         run: cargo publish --dry-run
 
       - name: Publish the Rust crate
         working-directory: rust_crate/
-        run: cargo publish
+        run: |
+          cargo login ${{ secrets.CRATES_IO_API_TOKEN }}
+          cargo publish

--- a/.github/workflows/publication.yaml
+++ b/.github/workflows/publication.yaml
@@ -8,7 +8,7 @@ name: publication
 # If you publish the packages on Windows with `dart pub publish`
 # script files are very likely to produce error on unix-like OS.
 # This issue has already been observed with `.sh` files.
-# That's why we use this manually-triggered Ubuntu workflow to publish packages.
+# That's why we must use this automated Ubuntu workflow to publish packages.
 
 on:
   push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.12.5
+
+- Automated publication.
+
 ## 4.12.4
 
 - Fixed permission related problems with build script files.

--- a/flutter_ffi_plugin/CHANGELOG.md
+++ b/flutter_ffi_plugin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.12.5
+
+- Automated publication.
+
 ## 4.12.4
 
 - Fixed permission related problems with build script files.

--- a/flutter_ffi_plugin/bin/rinf.dart
+++ b/flutter_ffi_plugin/bin/rinf.dart
@@ -263,7 +263,9 @@ Future<void> _buildWebassembly({bool isReleaseMode = false}) async {
 
   // Prepare the webassembly output path.
   final flutterProjectPath = Directory.current;
-  final wasmOutputPath = flutterProjectPath.uri.resolve('web/pkg').toFilePath();
+  final wasmOutputSubfolder = './web/pkg';
+  final wasmOutputPath =
+      flutterProjectPath.uri.resolve(wasmOutputSubfolder).toFilePath();
 
   // Build the webassembly module.
   print("Compiling Rust with `wasm-pack`...");
@@ -272,6 +274,7 @@ Future<void> _buildWebassembly({bool isReleaseMode = false}) async {
     wasmOutput: wasmOutputPath,
     isReleaseMode: isReleaseMode,
   );
+  print("Saved `.wasm` and `.js` files to `${wasmOutputSubfolder}`.");
 
   print("🎉 Webassembly module is now ready! 🎉");
 }

--- a/flutter_ffi_plugin/pubspec.yaml
+++ b/flutter_ffi_plugin/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rinf
 description: '"Rust as your Flutter backend, Flutter as your Rust frontend"'
-version: 4.12.4
+version: 4.12.5
 repository: https://github.com/cunarist/rinf
 
 environment:

--- a/rust_crate/Cargo.toml
+++ b/rust_crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinf"
-version = "4.12.4"
+version = "4.12.5"
 edition = "2021"
 license = "MIT"
 description = "Rust as your Flutter backend, Flutter as your Rust frontend"


### PR DESCRIPTION
## Changes

This PR adds API token integration and authentication step to upload packages to `crates.io` and `pub.dev` properly.

## Before Committing

_Please make sure that you've formatted the files._

```
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
