### PR TITLE
Disable `reqwest` on Android

### DIFF
--- a/flutter_ffi_plugin/example/native/sample_crate/Cargo.toml
+++ b/flutter_ffi_plugin/example/native/sample_crate/Cargo.toml
@@ -6,8 +6,10 @@ edition = "2021"
 [target.'cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))'.dependencies]
 machineid-rs = "1.2.4"
 
+[target.'cfg(not(any(target_os = "android")))'.dependencies]
+reqwest = "0.11.22"
+
 [dependencies]
 num = "0.4"
 image = "0.24.3"
 chrono = "0.4.31"
-reqwest = "0.11.22"

--- a/flutter_ffi_plugin/example/native/sample_crate/src/lib.rs
+++ b/flutter_ffi_plugin/example/native/sample_crate/src/lib.rs
@@ -35,7 +35,18 @@ pub fn get_current_time() -> DateTime<offset::Local> {
 }
 
 // `reqwest` supports all platforms, including web.
+// However, compiling it for Android on Windows can be challenging
+// due to its dependency on the `openssl-sys` crate,
+// which requires the corresponding C library to be installed on the system.
+// Compiling `reqwest` for Android is possible with the right system setup,
+// but it's intentionally disabled in our sample crate
+// to ensure that the example 'just works'.
 
+#[cfg(any(target_os = "android"))]
+pub async fn fetch_from_web_api(url: &str) -> String {
+    String::from("API fetching is disabled on this platform.")
+}
+#[cfg(not(any(target_os = "android")))]
 pub async fn fetch_from_web_api(url: &str) -> String {
     reqwest::get(url)
         .await

--- a/flutter_ffi_plugin/example/native/sample_crate/src/lib.rs
+++ b/flutter_ffi_plugin/example/native/sample_crate/src/lib.rs
@@ -40,7 +40,7 @@ pub fn get_current_time() -> DateTime<offset::Local> {
 // which requires the corresponding C library to be installed on the system.
 // Compiling `reqwest` for Android is possible with the right system setup,
 // but it's intentionally disabled in our sample crate
-// to ensure that the example 'just works'.
+// to ensure that the example app 'just works'.
 
 #[cfg(any(target_os = "android"))]
 pub async fn fetch_from_web_api(url: &str) -> String {


### PR DESCRIPTION
## Changes

The `reqwest` crate supports all platforms, including web. However, compiling it for Android on Windows can be challenging
due to its dependency on the `openssl-sys` crate, which requires the corresponding C library to be installed on the system. Compiling `reqwest` for Android is possible with the right system setup, but it's now intentionally disabled in our sample crate to ensure that the example app 'just works'.

- #206 
- https://github.com/cunarist/rinf/discussions/189#discussioncomment-7421171

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_ffi_plugin --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
