### PR TITLE
Support recursively watching on Linux

### DIFF
--- a/documentation/docs/writing-code.md
+++ b/documentation/docs/writing-code.md
@@ -318,25 +318,17 @@ While Rinf's API system may resemble that of web development, it relies only on 
 
 When you generate message code using the `rinf message` command, the resulting Dart and Rust modules' names and subpaths will precisely correspond to those of the `.proto` files.
 
-- `./messages` : The `.proto` files under here and its subdirectories will be used to generating message code.
+- `./messages` : The `.proto` files under here and its subdirectories will be used.
 - `./lib/messages` : The generated Dart code will be placed here.
 - `./native/hub/src/messages` : The generated Rust code will be placed here.
 
-### Continuous Message Generation
+### Continuous Watching
 
 If you add the optional argument `-w` or `--watch` to the `rinf message` command, the message code will automatically generated when `.proto` files are modified. If you add this argument, the command will not exit on its own.
 
 ```bash
 rinf message --watch
 ```
-
-Currently, recursive watching is not supported on all platforms.
-
-|         | While watching | One-time gen |
-| ------- | -------------- | ------------ |
-| Linux   | ❌             | ✅           |
-| macOS   | ✅             | ✅           |
-| Windows | ✅             | ✅           |
 
 ## 🖨️ Printing for Debugging
 

--- a/flutter_ffi_plugin/pubspec.yaml
+++ b/flutter_ffi_plugin/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   package_config: ^2.1.0
   js: ^0.6.4
   path: ^1.8.3
+  watcher: ^1.1.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
## Changes

Use the 3rd-party pub package(https://pub.dev/packages/watcher) instead of dart official API.

Support recursively watching on all platform now.
