### PR TITLE
Make the response mechanism much more efficient

### DIFF
--- a/flutter_ffi_plugin/example/native/hub/src/bridge/interface.rs
+++ b/flutter_ffi_plugin/example/native/hub/src/bridge/interface.rs
@@ -127,9 +127,9 @@ pub fn prepare_rust_response_stream(response_stream: StreamSink<RustResponseUniq
 }
 
 /// Returns a stream object in Dart that gives strings to print from Rust.
-pub fn prepare_rust_report_stream(print_stream: StreamSink<String>) {
+pub fn prepare_rust_report_stream(report_stream: StreamSink<String>) {
     let cell = REPORT_STREAM_SHARED.lock().unwrap();
-    cell.replace(Some(print_stream));
+    cell.replace(Some(report_stream));
 }
 
 /// Prepare channels that are used in the Rust world.

--- a/flutter_ffi_plugin/lib/rinf.dart
+++ b/flutter_ffi_plugin/lib/rinf.dart
@@ -16,7 +16,6 @@ export 'src/exports.dart' show RustSignal;
 /// You can see the usage example at
 /// https://pub.dev/packages/rinf/example.
 final rustBroadcaster = StreamController<RustSignal>.broadcast();
-late final Stream<RustResponseUnique> _responseStream;
 final _responseCompleters = Map<int, Completer<RustResponse>>();
 final _requestIdGenerator = _IdGenerator();
 
@@ -30,8 +29,8 @@ class Rinf {
     rustSignalStream.listen((rustSignal) {
       rustBroadcaster.add(rustSignal);
     });
-    _responseStream = api.prepareRustResponseStream();
-    _responseStream.listen((rustResponseUnique) {
+    final rustResponseUniqueStream = api.prepareRustResponseStream();
+    rustResponseUniqueStream.listen((rustResponseUnique) {
       final interactionId = rustResponseUnique.id;
       final responseCompleter = _responseCompleters.remove(interactionId);
       if (responseCompleter != null) {

--- a/flutter_ffi_plugin/lib/rinf.dart
+++ b/flutter_ffi_plugin/lib/rinf.dart
@@ -73,11 +73,11 @@ Future<RustResponse> requestToRust(
   Duration? timeout = const Duration(seconds: 60),
 }) async {
   final interactionId = _requestIdGenerator.generateId();
-  final requestUnique = RustRequestUnique(
+  final rustRequestUnique = RustRequestUnique(
     id: interactionId,
     request: rustRequest,
   );
-  api.requestToRust(requestUnique: requestUnique);
+  api.requestToRust(requestUnique: rustRequestUnique);
   final previousCompleter = _responseCompleters.remove(interactionId);
   if (previousCompleter != null) {
     previousCompleter.completeError(StateError(

--- a/flutter_ffi_plugin/lib/rinf.dart
+++ b/flutter_ffi_plugin/lib/rinf.dart
@@ -73,11 +73,6 @@ Future<RustResponse> requestToRust(
   Duration? timeout = const Duration(seconds: 60),
 }) async {
   final interactionId = _requestIdGenerator.generateId();
-  final rustRequestUnique = RustRequestUnique(
-    id: interactionId,
-    request: rustRequest,
-  );
-  api.requestToRust(requestUnique: rustRequestUnique);
   final previousCompleter = _responseCompleters.remove(interactionId);
   if (previousCompleter != null) {
     previousCompleter.completeError(StateError(
@@ -86,6 +81,11 @@ Future<RustResponse> requestToRust(
   }
   final responseCompleter = Completer<RustResponse>();
   _responseCompleters[interactionId] = responseCompleter;
+  final rustRequestUnique = RustRequestUnique(
+    id: interactionId,
+    request: rustRequest,
+  );
+  api.requestToRust(requestUnique: rustRequestUnique);
   final RustResponse rustResponse;
   if (timeout != null) {
     rustResponse = await responseCompleter.future.timeout(


### PR DESCRIPTION
## Changes

With this change, each pending Dart function simply awaits only the specific Rust response that it should accept(without checking everything). Each Dart task was checking all Rust responses before this PR.

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_ffi_plugin --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
