### PR TITLE
ignore example directory to pub.dev

### DIFF
--- a/flutter_ffi_plugin/.pubignore
+++ b/flutter_ffi_plugin/.pubignore
@@ -1,0 +1,1 @@
+example


### PR DESCRIPTION
I notice the package download from pub.dev contains example directory, but it does not need to publish to pub.dev.

From https://dart.dev/tools/pub/publishing , add .pubignore file.


