### PR TITLE
Add proper license files

### DIFF
--- a/flutter_ffi_plugin/lib/src/engine/LICENSE
+++ b/flutter_ffi_plugin/lib/src/engine/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 fzyzcjy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/flutter_ffi_plugin/lib/src/engine/README
+++ b/flutter_ffi_plugin/lib/src/engine/README
@@ -1,0 +1,2 @@
+Source: https://github.com/fzyzcjy/flutter_rust_bridge
+License: MIT

--- a/rust_crate/src/engine/LICENSE
+++ b/rust_crate/src/engine/LICENSE
@@ -1,1 +1,21 @@
-Add a license file
+MIT License
+
+Copyright (c) 2021 fzyzcjy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/rust_crate/src/engine/LICENSE
+++ b/rust_crate/src/engine/LICENSE
@@ -1,0 +1,1 @@
+Add a license file

--- a/rust_crate/src/engine/README
+++ b/rust_crate/src/engine/README
@@ -1,0 +1,2 @@
+Source: https://github.com/fzyzcjy/flutter_rust_bridge
+License: MIT


### PR DESCRIPTION
## Changes

The `flutter_rust_bridge`'s use under the MIT license does permit copies and modifications, but it necessitates the inclusion of the exact MIT license in all reproductions, which is currently absent.

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_ffi_plugin --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
