### PR TITLE
Provide Protobuf compiler automatically

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -12,6 +12,5 @@ _Please provide the output from the command below, using markdown codeblock synt
 
 ```bash
 rustc --version
-protoc --version
 flutter doctor
 ```

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -57,11 +57,6 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Setup Protobuf compiler
-        uses: arduino/setup-protoc@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Setup Ninja and GTK3 toolchain (Only Linux target)
         if: matrix.target == 'linux'
         run: |

--- a/.github/workflows/quality_control.yaml
+++ b/.github/workflows/quality_control.yaml
@@ -34,11 +34,6 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Setup Protobuf compiler
-        uses: arduino/setup-protoc@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install Clippy
         run: rustup component add clippy
 

--- a/documentation/docs/installing-components.md
+++ b/documentation/docs/installing-components.md
@@ -1,15 +1,12 @@
 # Installing Components
 
-To get started, you need to have [Flutter SDK](https://docs.flutter.dev/get-started/install), [Rust toolchain](https://www.rust-lang.org/tools/install), and [Protobuf compiler](https://grpc.io/docs/protoc-installation/) installed on your system.
+To get started, you need to have [Flutter SDK](https://docs.flutter.dev/get-started/install) and [Rust toolchain](https://www.rust-lang.org/tools/install) installed on your system.
 
-> If you're working on Linux, do not install Flutter from `snap`. Flutter from `snap` comes with its own binary linker called `ld`, which is fundamentally incompatible with Rust. Instead, follow the manual installation method as written in the Flutter docs.
-
-After the installation, verify your system's readiness with the following commands. Make sure you have installed all the subcomponents that Flutter suggests. If there are no issues in the output, you are good to go onto the next step!
+Once you're done with the installations, verify your system's readiness with the following commands. Make sure you have installed all the subcomponents that Flutter suggests. If there are no issues in the output, you are good to go onto the next step!
 
 ```bash
 rustc --version
-protoc --version
 flutter doctor
 ```
 
-> For those who aren't familiar, Protobuf is a popular, language-neutral, binary serialization format for structured messages, made by Google.
+> If you're working on Linux, do not install Flutter from `snap`. Flutter from `snap` comes with its own binary linker called `ld`, which is fundamentally incompatible with Rust. Instead, follow the manual installation method as written in the Flutter docs.

--- a/flutter_ffi_plugin/bin/rinf.dart
+++ b/flutter_ffi_plugin/bin/rinf.dart
@@ -191,16 +191,14 @@ utilizing the capabilities of the
 [Rinf](https://pub.dev/packages/rinf) framework.
 
 To run and build this app, you need to have
-[Flutter SDK](https://docs.flutter.dev/get-started/install),
-[Rust toolchain](https://www.rust-lang.org/tools/install),
-and [Protobuf compiler](https://grpc.io/docs/protoc-installation)
+[Flutter SDK](https://docs.flutter.dev/get-started/install)
+and [Rust toolchain](https://www.rust-lang.org/tools/install)
 installed on your system.
 You can check that your system is ready with the commands below.
 Note that all the Flutter subcomponents should be installed.
 
 ```bash
 rustc --version
-protoc --version
 flutter doctor
 ```
 

--- a/flutter_ffi_plugin/example/README.md
+++ b/flutter_ffi_plugin/example/README.md
@@ -9,16 +9,14 @@ utilizing the capabilities of the
 [Rinf](https://pub.dev/packages/rinf) framework.
 
 To run and build this app, you need to have
-[Flutter SDK](https://docs.flutter.dev/get-started/install),
-[Rust toolchain](https://www.rust-lang.org/tools/install),
-and [Protobuf compiler](https://grpc.io/docs/protoc-installation)
+[Flutter SDK](https://docs.flutter.dev/get-started/install)
+and [Rust toolchain](https://www.rust-lang.org/tools/install)
 installed on your system.
 You can check that your system is ready with the commands below.
 Note that all the Flutter subcomponents should be installed.
 
 ```bash
 rustc --version
-protoc --version
 flutter doctor
 ```
 

--- a/rust_crate/Cargo.toml
+++ b/rust_crate/Cargo.toml
@@ -10,11 +10,11 @@ documentation = "https://rinf.cunarist.com"
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 os-thread-local = "0.1.3"
 backtrace = "0.3.69"
+protoc-prebuilt = "0.2.0"
+home = "0.5.9"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 js-sys = "0.3.65"
 
 [dependencies]
 lazy_static = "1.4.0"
-protoc-prebuilt = "0.2.0"
-home = "0.5.9"

--- a/rust_crate/Cargo.toml
+++ b/rust_crate/Cargo.toml
@@ -16,3 +16,5 @@ js-sys = "0.3.65"
 
 [dependencies]
 lazy_static = "1.4.0"
+protoc-prebuilt = "0.2.0"
+home = "0.5.9"

--- a/rust_crate/src/main.rs
+++ b/rust_crate/src/main.rs
@@ -1,7 +1,23 @@
 use std::env;
+use std::fs;
 use std::process::Command;
 
 fn main() {
+    // Install and remember Protobuf compiler's path
+    let home_path = home::home_dir().unwrap();
+    let out_path = home_path.join(".local").join("bin");
+    println!("{:?}", out_path);
+    fs::create_dir_all(&out_path).unwrap();
+    env::set_var("OUT_DIR", out_path.to_str().unwrap());
+    let (protoc_path, _) = protoc_prebuilt::init("22.0").unwrap();
+    println!("{:?}", protoc_path.parent().unwrap().to_path_buf());
+    let mut path_var = match env::var_os("PATH") {
+        Some(val) => env::split_paths(&val).collect::<Vec<_>>(),
+        None => Vec::new(),
+    };
+    path_var.push(protoc_path.parent().unwrap().to_path_buf());
+    env::set_var("PATH", env::join_paths(path_var).unwrap());
+
     // Get command-line arguments excluding the program name
     let dart_command_args: Vec<String> = env::args().skip(1).collect();
 

--- a/rust_crate/src/main.rs
+++ b/rust_crate/src/main.rs
@@ -1,8 +1,9 @@
-use std::env;
-use std::fs;
-use std::process::Command;
-
+#[cfg(not(target_family = "wasm"))]
 fn main() {
+    use std::env;
+    use std::fs;
+    use std::process::Command;
+
     // Install and remember Protobuf compiler's path
     let home_path = home::home_dir().unwrap();
     let out_path = home_path.join(".local").join("bin");
@@ -33,4 +34,9 @@ fn main() {
 
     // Execute the command
     let _ = command.status();
+}
+
+#[cfg(target_family = "wasm")]
+fn main() {
+    // Separate dummy function to make the linter happy
 }


### PR DESCRIPTION
## Changes

With this PR, users don't have to install Protobuf compiler(protoc) manually anymore.

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_ffi_plugin --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
