### PR TITLE
Use installed protoc first

### DIFF
--- a/documentation/docs/installing-components.md
+++ b/documentation/docs/installing-components.md
@@ -10,3 +10,5 @@ flutter doctor
 ```
 
 > If you're working on Linux, do not install Flutter from `snap`. Flutter from `snap` comes with its own binary linker called `ld`, which is fundamentally incompatible with Rust. Instead, follow the manual installation method as written in the Flutter docs.
+
+> By default, Rinf automatically prepares `protoc`, the Protobuf compiler. If you encounter issues with this automated installation, possibly due to GitHub API access restrictions, you can [manually install](https://grpc.io/docs/protoc-installation/) `protoc` on your machine and add it to PATH. In this scenario, verify the installation by running the command `protoc --version` to ensure that the Protobuf compiler is ready on your machine.

--- a/rust_crate/Cargo.toml
+++ b/rust_crate/Cargo.toml
@@ -13,6 +13,7 @@ os-thread-local = "0.1.3"
 backtrace = "0.3.69"
 protoc-prebuilt = "0.2.0"
 home = "0.5.9"
+clap = { version = "4", features = ["derive"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 js-sys = "0.3.67"

--- a/rust_crate/Cargo.toml
+++ b/rust_crate/Cargo.toml
@@ -8,12 +8,14 @@ repository = "https://github.com/cunarist/rinf"
 documentation = "https://rinf.cunarist.com"
 rust-version = "1.70"
 
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 os-thread-local = "0.1.3"
 backtrace = "0.3.69"
 protoc-prebuilt = "0.2.0"
 home = "0.5.9"
-clap = { version = "4", features = ["derive"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 js-sys = "0.3.67"

--- a/rust_crate/Cargo.toml
+++ b/rust_crate/Cargo.toml
@@ -9,13 +9,13 @@ documentation = "https://rinf.cunarist.com"
 rust-version = "1.70"
 
 [dependencies]
-which = "6.0.0"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 os-thread-local = "0.1.3"
 backtrace = "0.3.69"
 protoc-prebuilt = "0.2.0"
 home = "0.5.9"
+which = "6.0.0"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 js-sys = "0.3.67"

--- a/rust_crate/Cargo.toml
+++ b/rust_crate/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/cunarist/rinf"
 documentation = "https://rinf.cunarist.com"
 rust-version = "1.70"
 
+[dependencies]
+which = "6.0.0"
+
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 os-thread-local = "0.1.3"
 backtrace = "0.3.69"

--- a/rust_crate/Cargo.toml
+++ b/rust_crate/Cargo.toml
@@ -8,9 +8,6 @@ repository = "https://github.com/cunarist/rinf"
 documentation = "https://rinf.cunarist.com"
 rust-version = "1.70"
 
-[dependencies]
-clap = { version = "4", features = ["derive"] }
-
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 os-thread-local = "0.1.3"
 backtrace = "0.3.69"

--- a/rust_crate/Cargo.toml
+++ b/rust_crate/Cargo.toml
@@ -8,8 +8,6 @@ repository = "https://github.com/cunarist/rinf"
 documentation = "https://rinf.cunarist.com"
 rust-version = "1.70"
 
-[dependencies]
-
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 os-thread-local = "0.1.3"
 backtrace = "0.3.69"

--- a/rust_crate/src/main.rs
+++ b/rust_crate/src/main.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(ignore_errors = true)]
 struct Args {
     dart_args: Vec<String>,
     #[arg(short, long)]

--- a/rust_crate/src/main.rs
+++ b/rust_crate/src/main.rs
@@ -1,17 +1,37 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+struct Args {
+    dart_args: Vec<String>,
+    #[arg(short, long)]
+    protoc_path: Option<String>,
+}
+
 #[cfg(not(target_family = "wasm"))]
 fn main() {
     use std::env;
     use std::fs;
     use std::path;
+    use std::path::PathBuf;
     use std::process;
+    use std::str::FromStr;
 
-    // Install Protobuf compiler and get the path.
-    let home_path = home::home_dir().unwrap();
-    let out_path = home_path.join(".local").join("bin");
-    fs::create_dir_all(&out_path).unwrap();
-    env::set_var("OUT_DIR", out_path.to_str().unwrap());
-    let (protoc_binary_path, _) = protoc_prebuilt::init("25.2").unwrap();
-    let protoc_path = protoc_binary_path.parent().unwrap().to_path_buf();
+    let args = Args::parse();
+
+    let protoc_path;
+
+    if let Some(p) = args.protoc_path {
+        let provided = PathBuf::from_str(&p).unwrap();
+        protoc_path = provided;
+    } else {
+        // Install Protobuf compiler and get the path.
+        let home_path = home::home_dir().unwrap();
+        let out_path = home_path.join(".local").join("bin");
+        fs::create_dir_all(&out_path).unwrap();
+        env::set_var("OUT_DIR", out_path.to_str().unwrap());
+        let (protoc_binary_path, _) = protoc_prebuilt::init("25.2").unwrap();
+        protoc_path = protoc_binary_path.parent().unwrap().to_path_buf();
+    }
 
     // Find the path where Dart executables are located.
     #[cfg(target_family = "windows")]
@@ -33,16 +53,13 @@ fn main() {
     path_var.push(pub_cache_bin_path);
     env::set_var("PATH", env::join_paths(path_var).unwrap());
 
-    // Get command-line arguments excluding the program name.
-    let dart_command_args: Vec<String> = env::args().skip(1).collect();
-
     // Build the command to run the Dart script.
     #[cfg(target_family = "windows")]
     let mut command = process::Command::new("dart.bat");
     #[cfg(target_family = "unix")]
     let mut command = process::Command::new("dart");
     command.args(["run", "rinf"]);
-    command.args(&dart_command_args);
+    command.args(&args.dart_args);
 
     // Execute the command
     let _ = command.status();

--- a/rust_crate/src/main.rs
+++ b/rust_crate/src/main.rs
@@ -5,11 +5,15 @@ fn main() {
     use std::path;
     use std::process;
 
+    // Verify Protobuf compiler.
     let protoc_path;
     if let Ok(installed) = which::which("protoc") {
+        // Get the path of Protobuf compiler that's already installed.
+        println!("Detected `protoc`, skipping auto installation.");
         protoc_path = installed.parent().unwrap().to_path_buf();
     } else {
         // Install Protobuf compiler and get the path.
+        println!("Preparing `protoc`...");
         let home_path = home::home_dir().unwrap();
         let out_path = home_path.join(".local").join("bin");
         fs::create_dir_all(&out_path).unwrap();

--- a/rust_crate/src/main.rs
+++ b/rust_crate/src/main.rs
@@ -5,13 +5,18 @@ fn main() {
     use std::path;
     use std::process;
 
-    // Install Protobuf compiler and get the path.
-    let home_path = home::home_dir().unwrap();
-    let out_path = home_path.join(".local").join("bin");
-    fs::create_dir_all(&out_path).unwrap();
-    env::set_var("OUT_DIR", out_path.to_str().unwrap());
-    let (protoc_binary_path, _) = protoc_prebuilt::init("25.2").unwrap();
-    let protoc_path = protoc_binary_path.parent().unwrap().to_path_buf();
+    let protoc_path;
+    if let Ok(installed) = which::which("protoc") {
+        protoc_path = installed.parent().unwrap().to_path_buf();
+    } else {
+        // Install Protobuf compiler and get the path.
+        let home_path = home::home_dir().unwrap();
+        let out_path = home_path.join(".local").join("bin");
+        fs::create_dir_all(&out_path).unwrap();
+        env::set_var("OUT_DIR", out_path.to_str().unwrap());
+        let (protoc_binary_path, _) = protoc_prebuilt::init("25.2").unwrap();
+        protoc_path = protoc_binary_path.parent().unwrap().to_path_buf();
+    }
 
     // Find the path where Dart executables are located.
     #[cfg(target_family = "windows")]

--- a/rust_crate/src/main.rs
+++ b/rust_crate/src/main.rs
@@ -1,44 +1,17 @@
-use clap::Parser;
-
-#[derive(Parser, Debug)]
-#[command(ignore_errors = true)]
-struct Args {
-    dart_args: Vec<String>,
-    #[arg(short, long)]
-    protoc_path: Option<String>,
-}
-
 #[cfg(not(target_family = "wasm"))]
 fn main() {
     use std::env;
     use std::fs;
     use std::path;
-    use std::path::PathBuf;
     use std::process;
-    use std::str::FromStr;
 
-    let args = Args::parse();
-
-    let protoc_path;
-
-    if let Some(p) = args.protoc_path {
-        let provided = PathBuf::from_str(&p).unwrap();
-        if !provided.exists() {
-            panic!(
-                "The provided protoc path {} doesn't exist.",
-                provided.display()
-            );
-        }
-        protoc_path = provided;
-    } else {
-        // Install Protobuf compiler and get the path.
-        let home_path = home::home_dir().unwrap();
-        let out_path = home_path.join(".local").join("bin");
-        fs::create_dir_all(&out_path).unwrap();
-        env::set_var("OUT_DIR", out_path.to_str().unwrap());
-        let (protoc_binary_path, _) = protoc_prebuilt::init("25.2").unwrap();
-        protoc_path = protoc_binary_path.parent().unwrap().to_path_buf();
-    }
+    // Install Protobuf compiler and get the path.
+    let home_path = home::home_dir().unwrap();
+    let out_path = home_path.join(".local").join("bin");
+    fs::create_dir_all(&out_path).unwrap();
+    env::set_var("OUT_DIR", out_path.to_str().unwrap());
+    let (protoc_binary_path, _) = protoc_prebuilt::init("25.2").unwrap();
+    let protoc_path = protoc_binary_path.parent().unwrap().to_path_buf();
 
     // Find the path where Dart executables are located.
     #[cfg(target_family = "windows")]
@@ -60,13 +33,16 @@ fn main() {
     path_var.push(pub_cache_bin_path);
     env::set_var("PATH", env::join_paths(path_var).unwrap());
 
+    // Get command-line arguments excluding the program name.
+    let dart_command_args: Vec<String> = env::args().skip(1).collect();
+
     // Build the command to run the Dart script.
     #[cfg(target_family = "windows")]
     let mut command = process::Command::new("dart.bat");
     #[cfg(target_family = "unix")]
     let mut command = process::Command::new("dart");
     command.args(["run", "rinf"]);
-    command.args(&args.dart_args);
+    command.args(&dart_command_args);
 
     // Execute the command
     let _ = command.status();

--- a/rust_crate/src/main.rs
+++ b/rust_crate/src/main.rs
@@ -23,6 +23,12 @@ fn main() {
 
     if let Some(p) = args.protoc_path {
         let provided = PathBuf::from_str(&p).unwrap();
+        if !provided.exists() {
+            panic!(
+                "The provided protoc path {} doesn't exist.",
+                provided.display()
+            );
+        }
         protoc_path = provided;
     } else {
         // Install Protobuf compiler and get the path.


### PR DESCRIPTION
## Summary
<del>
This PR introduces a flag `--protoc-path` (short: `-p`), allowing users to specify the protoc path. This is particularly useful for developers in China that unable to directly download binaries from GitHub, as they face restrictions imposed by the [Great Firewall](https://en.wikipedia.org/wiki/Great_Firewall). Therefore, when they initially use rinf, the installation action may timeout, resulting in the following error:

```console
$ thread 'main' panicked at /Users/ares/.cargo/registry/src/rsproxy.cn-0dccff568467c15b/rinf-6.1.0/src/main.rs:13:65:
called `Result::unwrap()` on an `Err` value: Ureq(Transport(Transport { kind: ConnectionFailed, message: Some("Connect error"), url: Some(Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("github.com")), port: None, path: "/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-osx-aarch_64.zip", query: None, fragment: None }), source: Some(Error { kind: TimedOut, message: "connection timed out" }) }))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
With this PR merged, one can use rinf like this:

```console
$ rinf message -p $(dirname $(which protoc))
```
</del>

Detecting the installed protoc instead of default downloading is helpful in addressing network restrictions, particularly the [problem](https://en.wikipedia.org/wiki/Great_Firewall) faced by developers in China.

## Changes

Fixes #284

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_ffi_plugin --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
