### PR TITLE
Fix `cd` can't work cross drives in Windows

### DIFF
--- a/flutter_ffi_plugin/cargokit/run_build_tool.cmd
+++ b/flutter_ffi_plugin/cargokit/run_build_tool.cmd
@@ -8,7 +8,7 @@ SET BASEDIR=%~dp0
 if not exist "%CARGOKIT_TOOL_TEMP_DIR%" (
     mkdir "%CARGOKIT_TOOL_TEMP_DIR%"
 )
-cd "%CARGOKIT_TOOL_TEMP_DIR%"
+cd /d "%CARGOKIT_TOOL_TEMP_DIR%"
 
 SET BUILD_TOOL_PKG_DIR=%BASEDIR%build_tool
 SET DART=%FLUTTER_ROOT%\bin\cache\dart-sdk\bin\dart


### PR DESCRIPTION
## Changes

In #189, somebody (and I) got a error like this when building Android.

```
Cannot operate on packages inside the cache.
Compiling bin/build_tool_runner.dart to kernel file bin/build_tool_runner.dill.
Error: Couldn't resolve the package 'build_tool' in 'package:build_tool/build_tool.dart'.
bin/build_tool_runner.dart:1:8: Error: Not found: 'package:build_tool/build_tool.dart'
import 'package:build_tool/build_tool.dart' as build_tool;
       ^
bin/build_tool_runner.dart:3:15: Error: Method not found: 'runMain'.
   build_tool.runMain(args);
              ^^^^^^^
Could not find a command named "bin\build_tool_runner.dill".

Usage: dart <command|dart-file> [arguments]

Global options:
-v, --verbose               Show additional command output.
    --version               Print the Dart SDK version.
    --enable-analytics      Enable analytics.
    --disable-analytics     Disable analytics.
    --suppress-analytics    Disallow analytics for this `dart *` run without changing the analytics configuration.
-h, --help                  Print this usage information.

Available commands:
  analyze    Analyze Dart code in a directory.
  compile    Compile Dart to various formats.
  create     Create a new Dart project.
  devtools   Open DevTools (optionally connecting to an existing application).
  doc        Generate API documentation for Dart projects.
  fix        Apply automated fixes to Dart source code.
  format     Idiomatically format Dart source code.
  info       Show diagnostic information about the installed tooling.
  pub        Work with packages.
  run        Run a Dart program.
  test       Run tests for a project.

Run "dart help <command>" for more information about a command.
See https://dart.dev/tools/dart-tool for detailed documentation.

FAILURE: Build failed with an exception.
```

I inspect the reason and find this command not work at all. [run_build_tool.cmd#L11](https://github.com/cunarist/rinf/blob/ca87b83aceee5ad74a1255327f709286d7d103c5/flutter_ffi_plugin/cargokit/run_build_tool.cmd#L11) 

This error was causing by the different drive of pub cache and project dir.

https://stackoverflow.com/questions/11065421/command-Prompt-wont-change-directory-to-another-drive

After I add the `/d` argument to `cd`, it works successfully now.

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_ffi_plugin --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
