### PR TITLE
Update message.dart

### DIFF
--- a/flutter_ffi_plugin/bin/src/message.dart
+++ b/flutter_ffi_plugin/bin/src/message.dart
@@ -391,7 +391,7 @@ Future<void> initializeRust() async {
 
 Future<void> finalizeRust() async {
   stopRustLogic();
-  await Future.delayed(Duration(milliseconds: 10));
+  await Future.delayed(const Duration(milliseconds: 10));
 }
 
 final signalHandlers = <int, void Function(Uint8List, Uint8List?)>{


### PR DESCRIPTION
Added 'const' keyword to the consturctor invocation to fix 'prefer_const_constructors` lint rule violation

## Changes

Fixes #304 

## Before Committing
```
dart analyze --fatal-infos
Analyzing flutter_analyze...

   info • lib\messages\generated.dart:15:24 • Use 'const' with the constructor to improve performance. Try adding the 'const' keyword to the constructor invocation. • prefer_const_constructors

1 issue found.

```


_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_ffi_plugin --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
