### PR TITLE
Fix messages with empty bytes and seprate binary signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ MySchemaInput(
   fieldOne: 1,
   fieldTwo: 2,
   fieldThree: 3,
-).sendSignalToRust(null)
+).sendSignalToRust()
 
 final stream = MySchemaOutput.rustSignalStream;
 await for (final rustSignal in stream) {
@@ -49,7 +49,7 @@ MySchemaOutput {
     field_four: 4,
     field_five: 5,
     field_six: 6,
-}.send_signal_to_dart(None)
+}.send_signal_to_dart()
 
 let mut receiver = MySchemaInput::get_dart_signal_receiver();
 while let Some(dart_signal) = receiver.recv().await {

--- a/documentation/docs/frequently-asked-questions.md
+++ b/documentation/docs/frequently-asked-questions.md
@@ -226,7 +226,7 @@ onPressed: () async {
   MyUniqueInput(
     beforeNumber: 3,
     interactionId: currentInteractionId,
-  ).sendSignalToRust(null);
+  ).sendSignalToRust();
   currentInteractionId += 1;
   final myUniqueOutput = await completer.future;
 },
@@ -244,7 +244,7 @@ pub async fn respond() {
             interaction_id: my_unique_input.interaction_id,
             after_number: my_unique_input.before_number + 4,
         }
-        .send_signal_to_dart(None);
+        .send_signal_to_dart();
     }
 }
 ```

--- a/documentation/docs/messaging.md
+++ b/documentation/docs/messaging.md
@@ -4,7 +4,7 @@
 
     If you are using Rinf version 5 or earlier, please refer to the [historical documentation](https://github.com/cunarist/rinf/blob/v5.4.0/documentation/docs/writing-code.md). With the introduction of Rinf version 6, a simpler way for communication between Dart and Rust has been implemented, and the system has undergone significant changes.
 
-Special comments empower Protobuf messages with the capability to transmit signals across Dart and Rust. This is achieved by allowing Rinf's code generator to create the necessary channels for communication between Dart and Rust.
+Marking Protobuf messages with special comments empower them with the capability to transmit signals across Dart and Rust. This is achieved by allowing Rinf's code generator to create the necessary channels for communication between Dart and Rust.
 
 There are 2 types of special comments that you can mark messages with.
 
@@ -18,12 +18,34 @@ message MyDataInput { ... }
 ```
 
 ```dart title="Dart"
-MyDataInput( ... ).sendSignalToRust(null);
+MyDataInput( ... ).sendSignalToRust();
 ```
 
 ```rust title="Rust"
 let mut receiver = MyDataInput::get_dart_signal_receiver();
 while let Some(dart_signal) = receiver.recv().await {
+    let message: MyDataInput = dart_signal.message;
+    // Custom Rust logic here
+}
+```
+
+Use `[RINF:DART-SIGNAL-BINARY]` to include binary data without the overhead of serialization.
+
+```proto title="Protobuf"
+// [RINF:DART-SIGNAL-BINARY]
+message MyDataInput { ... }
+```
+
+```dart title="Dart"
+Uint8List binary = Uint8List(64);
+MyDataInput( ... ).sendSignalToRustWithBinary(binary);
+```
+
+```rust title="Rust"
+let mut receiver = MyDataInput::get_dart_signal_receiver();
+while let Some(dart_signal) = receiver.recv().await {
+    let message: MyDataInput = dart_signal.message;
+    let binary: Vec<u8> = dart_signal.binary.unwrap();
     // Custom Rust logic here
 }
 ```
@@ -38,18 +60,34 @@ message MyDataOutput { ... }
 ```
 
 ```dart title="Dart"
-fianl stream = MyDataOutput.rustSignalStream;
+final stream = MyDataOutput.rustSignalStream;
 await for (final rustSignal in stream) {
+    MyDataOutput message = rustSignal.message;
     // Custom Dart logic here
 }
 ```
 
 ```rust title="Rust"
-MyDataOutput { ... }.send_signal_to_dart(None);
+MyDataOutput { ... }.send_signal_to_dart();
 ```
 
-## 🗄️ Binary Data
+Use `[RINF:RUST-SIGNAL-BINARY]` to include binary data without the overhead of serialization.
 
-You can provide binary data as an argument to the `sendSignalToRust()` or `send_signal_to_dart()` method.
+```proto title="Protobuf"
+// [RINF:RUST-SIGNAL-BINARY]
+message MyDataOutput { ... }
+```
 
-Its type should be `Uint8List?` in Dart and `Option<Vec<u8>>` in Rust. Passing binary data separately is recommended over embedding it inside the Protobuf message for better performance, as it avoids the overhead of serialization.
+```dart title="Dart"
+final stream = MyDataOutput.rustSignalStream;
+await for (final rustSignal in stream) {
+    MyDataOutput message = rustSignal.message;
+    Uint8List binary = rustSignal.binary!;
+    // Custom Dart logic here
+}
+```
+
+```rust title="Rust"
+let binary: Vec<u8> = vec![0; 64];
+MyDataOutput { ... }.send_signal_to_dart_with_binary(binary);
+```

--- a/documentation/docs/messaging.md
+++ b/documentation/docs/messaging.md
@@ -38,7 +38,7 @@ message MyDataInput { ... }
 
 ```dart title="Dart"
 Uint8List binary = Uint8List(64);
-MyDataInput( ... ).sendSignalToRustWithBinary(binary);
+MyDataInput( ... ).sendSignalToRust(binary);
 ```
 
 ```rust title="Rust"
@@ -89,5 +89,5 @@ await for (final rustSignal in stream) {
 
 ```rust title="Rust"
 let binary: Vec<u8> = vec![0; 64];
-MyDataOutput { ... }.send_signal_to_dart_with_binary(binary);
+MyDataOutput { ... }.send_signal_to_dart(binary);
 ```

--- a/documentation/docs/messaging.md
+++ b/documentation/docs/messaging.md
@@ -37,7 +37,7 @@ message MyDataInput { ... }
 ```
 
 ```dart title="Dart"
-Uint8List binary = Uint8List(64);
+final binary = Uint8List(64);
 MyDataInput( ... ).sendSignalToRust(binary);
 ```
 
@@ -45,7 +45,7 @@ MyDataInput( ... ).sendSignalToRust(binary);
 let mut receiver = MyDataInput::get_dart_signal_receiver();
 while let Some(dart_signal) = receiver.recv().await {
     let message: MyDataInput = dart_signal.message;
-    let binary: Vec<u8> = dart_signal.binary.unwrap();
+    let binary: Vec<u8> = dart_signal.binary;
     // Custom Rust logic here
 }
 ```
@@ -82,7 +82,7 @@ message MyDataOutput { ... }
 final stream = MyDataOutput.rustSignalStream;
 await for (final rustSignal in stream) {
     MyDataOutput message = rustSignal.message;
-    Uint8List binary = rustSignal.binary!;
+    Uint8List binary = rustSignal.binary;
     // Custom Dart logic here
 }
 ```

--- a/documentation/docs/state-management.md
+++ b/documentation/docs/state-management.md
@@ -32,7 +32,7 @@ pub async fn do_something_with_state() {
     MyMessage {
        some_latest_state: vector.len() as i32,
     }
-    .send_signal_to_dart(None);
+    .send_signal_to_dart();
 }
 ```
 

--- a/documentation/docs/tutorial.md
+++ b/documentation/docs/tutorial.md
@@ -50,7 +50,7 @@ child: Column(
         MyPreciousData(
           inputNumbers: [3, 4, 5],
           inputString: 'Zero-cost abstraction',
-        ).sendSignalToRust(null); // GENERATED
+        ).sendSignalToRust(); // GENERATED
       },
       child: Text("Send a Signal from Dart to Rust"),
     ),
@@ -134,7 +134,7 @@ pub async fn stream_amazing_number() {
     let mut current_number: i32 = 1;
     loop {
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-        MyAmazingNumber { current_number }.send_signal_to_dart(None); // GENERATED
+        MyAmazingNumber { current_number }.send_signal_to_dart(); // GENERATED
         current_number += 1;
     }
 }
@@ -211,7 +211,7 @@ children: [
   ),
   ElevatedButton(
     onPressed: () {
-      MyTreasureInput().sendSignalToRust(null); // GENERATED
+      MyTreasureInput().sendSignalToRust(); // GENERATED
     },
     child: Text('Send the input'),
   ),
@@ -228,7 +228,7 @@ pub async fn tell_treasure() {
     let mut current_value: i32 = 1;
     let mut receiver = MyTreasureInput::get_dart_signal_receiver(); // GENERATED
     while let Some(_) = receiver.recv().await {
-        MyTreasureOutput { current_value }.send_signal_to_dart(None); // GENERATED
+        MyTreasureOutput { current_value }.send_signal_to_dart(); // GENERATED
         current_value += 1;
     }
 }

--- a/documentation/docs/writing-code.md
+++ b/documentation/docs/writing-code.md
@@ -6,9 +6,9 @@ We've covered how to pass signals[^1] between Dart and Rust in the previous tuto
 
 - **Field `message`:** It represents a message of a type defined by Protobuf. This field is always filled.
 
-- **Field `binary`:** This is a field designed to handle large binary data, potentially up to a few gigabytes. You can send any kind of binary data you wish, such as a high-resolution image or file data. This field is optional and can be `null` or `None`.
+- **Field `binary`:** This is a field designed to handle large binary data, potentially up to a few gigabytes. You can send any kind of binary data you wish, such as a high-resolution image or file data. This field carries empty `Uint8List` or `Vec<u8>` if the message is not marked as binary signal.
 
-It's important to note that creating a Protobuf `message` larger than a few megabytes is not recommended. For large data, split them into multiple signals, or use `binary` instead.[^2]
+It's important to note that creating a Protobuf `message` larger than a few megabytes is not recommended. For large data, split them into multiple signals, or use the `binary` field.[^2]
 
 [^1]: Rinf relies solely on native FFI for communication, avoiding the use of web protocols or hidden threads. The goal is to minimize performance overhead as much as possible.
 [^2]: Sending a serialized message or binary data is a zero-copy operation from Rust to Dart, while it involves a copy operation from Dart to Rust in memory. Keep in mind that Protobuf's serialization and deserialization does involve memory copy.

--- a/documentation/docs/writing-code.md
+++ b/documentation/docs/writing-code.md
@@ -4,14 +4,14 @@
 
 We've covered how to pass signals[^1] between Dart and Rust in the previous tutorial section. Now Let's delve into the meaning of each field of a signal.
 
-- **Field `message`:** It represents a message of a type defined by Protobuf. This field is mandatory.
+- **Field `message`:** It represents a message of a type defined by Protobuf. This field is always filled.
 
-- **Field `blob`:** This is a field designed to handle large binary data, potentially up to a few gigabytes. You can send any kind of binary data you wish, such as a high-resolution image or file data. This field is optional and can be set to `null` or `None`.
+- **Field `binary`:** This is a field designed to handle large binary data, potentially up to a few gigabytes. You can send any kind of binary data you wish, such as a high-resolution image or file data. This field is optional and can be `null` or `None`.
 
-It's important to note that creating a Protobuf `message` larger than a few megabytes is not recommended. For large data, split them into multiple signals, or use `blob` instead.[^2]
+It's important to note that creating a Protobuf `message` larger than a few megabytes is not recommended. For large data, split them into multiple signals, or use `binary` instead.[^2]
 
 [^1]: Rinf relies solely on native FFI for communication, avoiding the use of web protocols or hidden threads. The goal is to minimize performance overhead as much as possible.
-[^2]: Sending a serialized message or blob data is a zero-copy operation from Rust to Dart, while it involves a copy operation from Dart to Rust in memory. Keep in mind that Protobuf's serialization and deserialization does involve memory copy.
+[^2]: Sending a serialized message or binary data is a zero-copy operation from Rust to Dart, while it involves a copy operation from Dart to Rust in memory. Keep in mind that Protobuf's serialization and deserialization does involve memory copy.
 
 ## 📦 Message Details
 

--- a/documentation/overrides/home.html
+++ b/documentation/overrides/home.html
@@ -214,7 +214,7 @@
   fieldOne: 1,
   fieldTwo: 2,
   fieldThree: 3,
-).sendSignalToRust(null)
+).sendSignalToRust()
 
 final stream = MySchemaOutput.rustSignalStream;
 await for (final rustSignal in stream) {
@@ -231,7 +231,7 @@ await for (final rustSignal in stream) {
     field_four: 4,
     field_five: 5,
     field_six: 6,
-}.send_signal_to_dart(None)
+}.send_signal_to_dart()
 
 let mut receiver = MySchemaInput::get_dart_signal_receiver();
 while let Some(dart_signal) = receiver.recv().await {

--- a/flutter_ffi_plugin/README.md
+++ b/flutter_ffi_plugin/README.md
@@ -36,7 +36,7 @@ MySchemaInput(
   fieldOne: 1,
   fieldTwo: 2,
   fieldThree: 3,
-).sendSignalToRust(null)
+).sendSignalToRust()
 
 final stream = MySchemaOutput.rustSignalStream;
 await for (final rustSignal in stream) {
@@ -49,7 +49,7 @@ MySchemaOutput {
     field_four: 4,
     field_five: 5,
     field_six: 6,
-}.send_signal_to_dart(None)
+}.send_signal_to_dart()
 
 let mut receiver = MySchemaInput::get_dart_signal_receiver();
 while let Some(dart_signal) = receiver.recv().await {

--- a/flutter_ffi_plugin/bin/src/message.dart
+++ b/flutter_ffi_plugin/bin/src/message.dart
@@ -283,11 +283,18 @@ final ${camelName}Controller = StreamController<RustSignal<$messageName>>();
             rustPath,
             '''
 impl ${normalizePascal(messageName)} {
-    pub fn send_signal_to_dart(&self, blob: Option<Vec<u8>>) {
+    pub fn send_signal_to_dart(&self) {
         send_rust_signal(
             ${markedMessage.id},
             self.encode_to_vec(),
-            blob
+            None,
+        );
+    }
+    pub fn send_signal_to_dart_with_binary(&self, binary: Vec<u8>) {
+        send_rust_signal(
+            ${markedMessage.id},
+            self.encode_to_vec(),
+            Some(binary),
         );
     }
 }

--- a/flutter_ffi_plugin/bin/src/message.dart
+++ b/flutter_ffi_plugin/bin/src/message.dart
@@ -274,7 +274,7 @@ void sendSignalToRust() {
           await insertTextToFile(
             dartPath,
             '''
-void sendSignalToRustWithBinary(Uint8List binary) {
+void sendSignalToRust(Uint8List binary) {
   sendDartSignal(
     ${markedMessage.id},
     this.writeToBuffer(),
@@ -323,7 +323,7 @@ impl ${normalizePascal(messageName)} {
             rustPath,
             '''
 impl ${normalizePascal(messageName)} {
-    pub fn send_signal_to_dart_with_binary(&self, binary: Vec<u8>) {
+    pub fn send_signal_to_dart(&self, binary: Vec<u8>) {
         send_rust_signal(
             ${markedMessage.id},
             self.encode_to_vec(),

--- a/flutter_ffi_plugin/example/lib/main.dart
+++ b/flutter_ffi_plugin/example/lib/main.dart
@@ -73,7 +73,7 @@ class MyHomePage extends StatelessWidget {
                       ),
                     );
                   }
-                  final imageData = rustSignal.binary!;
+                  final imageData = rustSignal.binary;
                   return Container(
                     margin: const EdgeInsets.all(20),
                     width: 256,

--- a/flutter_ffi_plugin/example/lib/main.dart
+++ b/flutter_ffi_plugin/example/lib/main.dart
@@ -125,7 +125,7 @@ class MyHomePage extends StatelessWidget {
               sampleFieldTwo: false,
             ),
             dummyThree: [4, 5, 6],
-          ).sendSignalToRust(null);
+          ).sendSignalToRust();
         },
         tooltip: 'Increment',
         child: const Icon(Icons.add),

--- a/flutter_ffi_plugin/example/lib/main.dart
+++ b/flutter_ffi_plugin/example/lib/main.dart
@@ -73,7 +73,7 @@ class MyHomePage extends StatelessWidget {
                       ),
                     );
                   }
-                  final imageData = rustSignal.blob!;
+                  final imageData = rustSignal.binary!;
                   return Container(
                     margin: const EdgeInsets.all(20),
                     width: 256,

--- a/flutter_ffi_plugin/example/messages/fractal_art.proto
+++ b/flutter_ffi_plugin/example/messages/fractal_art.proto
@@ -3,7 +3,7 @@ package fractal_art;
 
 import "counter_number.proto";
 
-// [RINF:RUST-SIGNAL]
+// [RINF:RUST-SIGNAL-BINARY]
 // You can add your custom comments like this.
 // Protobuf's import statement also works well.
 message SampleFractal {

--- a/flutter_ffi_plugin/example/native/hub/src/sample_functions.rs
+++ b/flutter_ffi_plugin/example/native/hub/src/sample_functions.rs
@@ -44,7 +44,7 @@ pub async fn tell_numbers() {
             dummy_two: number_input.dummy_two,
             dummy_three: number_input.dummy_three,
         }
-        .send_signal_to_dart(None);
+        .send_signal_to_dart();
     }
 }
 
@@ -98,7 +98,7 @@ pub async fn stream_fractal() {
                         sample_field_two: false,
                     }),
                 }
-                .send_signal_to_dart(Some(fractal_image));
+                .send_signal_to_dart_with_binary(fractal_image);
             };
         }
     });
@@ -113,7 +113,7 @@ async fn use_messages() {
         kind: 3,
         oneof_input: Some(sample_output::OneofInput::Age(25)),
     }
-    .send_signal_to_dart(None)
+    .send_signal_to_dart()
 }
 
 // Business logic for testing various crates.

--- a/flutter_ffi_plugin/example/native/hub/src/sample_functions.rs
+++ b/flutter_ffi_plugin/example/native/hub/src/sample_functions.rs
@@ -98,7 +98,7 @@ pub async fn stream_fractal() {
                         sample_field_two: false,
                     }),
                 }
-                .send_signal_to_dart_with_binary(fractal_image);
+                .send_signal_to_dart(fractal_image);
             };
         }
     });

--- a/flutter_ffi_plugin/lib/rinf.dart
+++ b/flutter_ffi_plugin/lib/rinf.dart
@@ -31,21 +31,11 @@ void stopRustLogic() async {
 void sendDartSignal(
   int messageId,
   Uint8List messageBytes,
-  Uint8List? binary,
+  Uint8List binary,
 ) async {
-  bool binaryIncluded;
-  Uint8List binaryBytes;
-  if (binary == null) {
-    binaryIncluded = false;
-    binaryBytes = Uint8List(0);
-  } else {
-    binaryIncluded = true;
-    binaryBytes = binary;
-  }
   sendDartSignalExtern(
     messageId,
     messageBytes,
-    binaryIncluded,
-    binaryBytes,
+    binary,
   );
 }

--- a/flutter_ffi_plugin/lib/rinf.dart
+++ b/flutter_ffi_plugin/lib/rinf.dart
@@ -31,21 +31,21 @@ void stopRustLogic() async {
 void sendDartSignal(
   int messageId,
   Uint8List messageBytes,
-  Uint8List? blob,
+  Uint8List? binary,
 ) async {
-  bool blobValid;
-  Uint8List blobBytes;
-  if (blob == null) {
-    blobValid = false;
-    blobBytes = Uint8List(0);
+  bool binaryIncluded;
+  Uint8List binaryBytes;
+  if (binary == null) {
+    binaryIncluded = false;
+    binaryBytes = Uint8List(0);
   } else {
-    blobValid = true;
-    blobBytes = blob;
+    binaryIncluded = true;
+    binaryBytes = binary;
   }
   sendDartSignalExtern(
     messageId,
     messageBytes,
-    blobValid,
-    blobBytes,
+    binaryIncluded,
+    binaryBytes,
   );
 }

--- a/flutter_ffi_plugin/lib/src/interface.dart
+++ b/flutter_ffi_plugin/lib/src/interface.dart
@@ -6,11 +6,11 @@ import 'dart:typed_data';
 typedef HandleRustSignal = void Function(int, Uint8List, Uint8List?);
 
 /// This contains a message from Rust.
-/// Optionally, a custom binary called `blob` can also be included.
+/// Optionally, a custom binary called `binary` can also be included.
 /// This type is generic, and the message
 /// can be of any type declared in Protobuf.
 class RustSignal<T> {
   T message;
-  Uint8List? blob;
-  RustSignal(this.message, this.blob);
+  Uint8List? binary;
+  RustSignal(this.message, this.binary);
 }

--- a/flutter_ffi_plugin/lib/src/interface.dart
+++ b/flutter_ffi_plugin/lib/src/interface.dart
@@ -3,7 +3,7 @@ import 'dart:typed_data';
 /// This type represents a function
 /// that can accept raw signal data from Rust
 /// and handle it accordingly.
-typedef HandleRustSignal = void Function(int, Uint8List, Uint8List?);
+typedef HandleRustSignal = void Function(int, Uint8List, Uint8List);
 
 /// This contains a message from Rust.
 /// Optionally, a custom binary called `binary` can also be included.
@@ -11,6 +11,6 @@ typedef HandleRustSignal = void Function(int, Uint8List, Uint8List?);
 /// can be of any type declared in Protobuf.
 class RustSignal<T> {
   T message;
-  Uint8List? binary;
+  Uint8List binary;
   RustSignal(this.message, this.binary);
 }

--- a/flutter_ffi_plugin/lib/src/interface_os.dart
+++ b/flutter_ffi_plugin/lib/src/interface_os.dart
@@ -77,14 +77,14 @@ void stopRustLogicExtern() {
 Future<void> sendDartSignalExtern(
   int messageId,
   Uint8List messageBytes,
-  bool blobValid,
-  Uint8List blobBytes,
+  bool binaryIncluded,
+  Uint8List binaryBytes,
 ) async {
   final Pointer<Uint8> messageMemory = malloc.allocate(messageBytes.length);
   messageMemory.asTypedList(messageBytes.length).setAll(0, messageBytes);
 
-  final Pointer<Uint8> blobMemory = malloc.allocate(blobBytes.length);
-  blobMemory.asTypedList(blobBytes.length).setAll(0, blobBytes);
+  final Pointer<Uint8> binaryMemory = malloc.allocate(binaryBytes.length);
+  binaryMemory.asTypedList(binaryBytes.length).setAll(0, binaryBytes);
 
   final rustFunction = rustLibrary.lookupFunction<
       Void Function(
@@ -108,9 +108,9 @@ Future<void> sendDartSignalExtern(
     messageId,
     messageMemory.cast(),
     messageBytes.length,
-    blobValid,
-    blobMemory.cast(),
-    blobBytes.length,
+    binaryIncluded,
+    binaryMemory.cast(),
+    binaryBytes.length,
   );
 
   // Note that we do not free memory here with `malloc.free()`,

--- a/flutter_ffi_plugin/lib/src/interface_os.dart
+++ b/flutter_ffi_plugin/lib/src/interface_os.dart
@@ -26,7 +26,9 @@ Future<void> prepareInterfaceExtern(
 
   // Listen to Rust via isolate port.
   rustSignalPort.listen((rustSignalRaw) {
-    Uint8List? binary = rustSignalRaw[2];
+    final messageId = rustSignalRaw[0];
+    var messageBytes = rustSignalRaw[1];
+    var binary = rustSignalRaw[2];
     if (binary == null) {
       // Rust will send null if the vector is empty.
       // Converting is needed on the Dart side.
@@ -38,8 +40,6 @@ Future<void> prepareInterfaceExtern(
       print(rustReport);
       return;
     }
-    final messageId = rustSignalRaw[0];
-    var messageBytes = rustSignalRaw[1];
     if (messageBytes == null) {
       // Rust will send null if the vector is empty.
       // Converting is needed on the Dart side.

--- a/flutter_ffi_plugin/lib/src/interface_web.dart
+++ b/flutter_ffi_plugin/lib/src/interface_web.dart
@@ -17,20 +17,13 @@ Future<void> prepareInterfaceExtern(
   jsObject['send_rust_signal_extern'] = (
     int messageId,
     Uint8List messageBytes,
-    bool binaryIncluded,
-    Uint8List binaryBytes,
+    Uint8List binary,
   ) {
     if (messageId == -1) {
       // -1 is a special message ID for Rust reports.
-      String rustReport = utf8.decode(binaryBytes);
+      String rustReport = utf8.decode(binary);
       print(rustReport);
       return;
-    }
-    Uint8List? binary;
-    if (binaryIncluded) {
-      binary = binaryBytes;
-    } else {
-      binary = null;
     }
     handleRustSignal(messageId, messageBytes, binary);
   };
@@ -51,14 +44,12 @@ void stopRustLogicExtern() {
 void sendDartSignalExtern(
   int messageId,
   Uint8List messageBytes,
-  bool binaryIncluded,
-  Uint8List binaryBytes,
+  Uint8List binary,
 ) {
   final jsObject = js.context['rinf'] as js.JsObject;
   jsObject.callMethod('send_dart_signal_extern', [
     messageId,
     messageBytes,
-    binaryIncluded,
-    binaryBytes,
+    binary,
   ]);
 }

--- a/flutter_ffi_plugin/lib/src/interface_web.dart
+++ b/flutter_ffi_plugin/lib/src/interface_web.dart
@@ -17,22 +17,22 @@ Future<void> prepareInterfaceExtern(
   jsObject['send_rust_signal_extern'] = (
     int messageId,
     Uint8List messageBytes,
-    bool blobValid,
-    Uint8List blobBytes,
+    bool binaryIncluded,
+    Uint8List binaryBytes,
   ) {
     if (messageId == -1) {
       // -1 is a special message ID for Rust reports.
-      String rustReport = utf8.decode(blobBytes);
+      String rustReport = utf8.decode(binaryBytes);
       print(rustReport);
       return;
     }
-    Uint8List? blob;
-    if (blobValid) {
-      blob = blobBytes;
+    Uint8List? binary;
+    if (binaryIncluded) {
+      binary = binaryBytes;
     } else {
-      blob = null;
+      binary = null;
     }
-    handleRustSignal(messageId, messageBytes, blob);
+    handleRustSignal(messageId, messageBytes, binary);
   };
 }
 
@@ -51,14 +51,14 @@ void stopRustLogicExtern() {
 void sendDartSignalExtern(
   int messageId,
   Uint8List messageBytes,
-  bool blobValid,
-  Uint8List blobBytes,
+  bool binaryIncluded,
+  Uint8List binaryBytes,
 ) {
   final jsObject = js.context['rinf'] as js.JsObject;
   jsObject.callMethod('send_dart_signal_extern', [
     messageId,
     messageBytes,
-    blobValid,
-    blobBytes,
+    binaryIncluded,
+    binaryBytes,
   ]);
 }

--- a/rust_crate/README.md
+++ b/rust_crate/README.md
@@ -36,7 +36,7 @@ MySchemaInput(
   fieldOne: 1,
   fieldTwo: 2,
   fieldThree: 3,
-).sendSignalToRust(null)
+).sendSignalToRust()
 
 final stream = MySchemaOutput.rustSignalStream;
 await for (final rustSignal in stream) {
@@ -49,7 +49,7 @@ MySchemaOutput {
     field_four: 4,
     field_five: 5,
     field_six: 6,
-}.send_signal_to_dart(None)
+}.send_signal_to_dart()
 
 let mut receiver = MySchemaInput::get_dart_signal_receiver();
 while let Some(dart_signal) = receiver.recv().await {

--- a/rust_crate/src/interface.rs
+++ b/rust_crate/src/interface.rs
@@ -16,15 +16,10 @@ pub type SharedCell<T> = OnceLock<Mutex<RefCell<Option<T>>>>;
 /// can be of any type declared in Protobuf.
 pub struct DartSignal<T> {
     pub message: T,
-    pub binary: Option<Vec<u8>>,
+    pub binary: Vec<u8>,
 }
 
 /// Send a signal to Dart.
-pub fn send_rust_signal(message_id: i32, message_bytes: Vec<u8>, binary: Option<Vec<u8>>) {
-    send_rust_signal_extern(
-        message_id,
-        message_bytes,
-        binary.is_some(),
-        binary.unwrap_or_default(),
-    );
+pub fn send_rust_signal(message_id: i32, message_bytes: Vec<u8>, binary: Vec<u8>) {
+    send_rust_signal_extern(message_id, message_bytes, binary);
 }

--- a/rust_crate/src/interface.rs
+++ b/rust_crate/src/interface.rs
@@ -11,12 +11,12 @@ use super::interface_web::*;
 pub type SharedCell<T> = OnceLock<Mutex<RefCell<Option<T>>>>;
 
 /// This contains a message from Dart.
-/// Optionally, a custom binary called `blob` can also be included.
+/// Optionally, a custom binary called `binary` can also be included.
 /// This type is generic, and the message
 /// can be of any type declared in Protobuf.
 pub struct DartSignal<T> {
     pub message: T,
-    pub blob: Option<Vec<u8>>,
+    pub binary: Option<Vec<u8>>,
 }
 
 /// Send a signal to Dart.

--- a/rust_crate/src/interface.rs
+++ b/rust_crate/src/interface.rs
@@ -20,11 +20,11 @@ pub struct DartSignal<T> {
 }
 
 /// Send a signal to Dart.
-pub fn send_rust_signal(message_id: i32, message_bytes: Vec<u8>, blob: Option<Vec<u8>>) {
+pub fn send_rust_signal(message_id: i32, message_bytes: Vec<u8>, binary: Option<Vec<u8>>) {
     send_rust_signal_extern(
         message_id,
         message_bytes,
-        blob.is_some(),
-        blob.unwrap_or_default(),
+        binary.is_some(),
+        binary.unwrap_or_default(),
     );
 }

--- a/rust_crate/src/interface_os.rs
+++ b/rust_crate/src/interface_os.rs
@@ -21,12 +21,7 @@ pub extern "C" fn prepare_isolate_extern(port: i64) {
     });
 }
 
-pub fn send_rust_signal_extern(
-    message_id: i32,
-    message_bytes: Vec<u8>,
-    binary_included: bool,
-    binary_bytes: Vec<u8>,
-) {
+pub fn send_rust_signal_extern(message_id: i32, message_bytes: Vec<u8>, binary: Vec<u8>) {
     let cell = DART_ISOLATE.get().unwrap().lock().unwrap();
     let dart_isolate = cell.borrow().unwrap();
 
@@ -34,7 +29,7 @@ pub fn send_rust_signal_extern(
     // because panic can occur from null pointers.
     // Instead, we will reconstruct the empty vector from the Dart side.
     let message_filled = !message_bytes.is_empty();
-    let binary_filled = !binary_bytes.is_empty();
+    let binary_filled = !binary.is_empty();
 
     dart_isolate.post(
         vec![
@@ -44,9 +39,8 @@ pub fn send_rust_signal_extern(
             } else {
                 ().into_dart()
             },
-            binary_included.into_dart(),
             if binary_filled {
-                ZeroCopyBuffer(binary_bytes).into_dart()
+                ZeroCopyBuffer(binary).into_dart()
             } else {
                 ().into_dart()
             },

--- a/rust_crate/src/interface_web.rs
+++ b/rust_crate/src/interface_web.rs
@@ -7,8 +7,8 @@ extern "C" {
     pub fn send_rust_signal_extern_raw(
         resource: i32,
         message_bytes: Uint8Array,
-        blob_valid: bool,
-        blob_bytes: Uint8Array,
+        binary_included: bool,
+        binary_bytes: Uint8Array,
     );
 }
 

--- a/rust_crate/src/interface_web.rs
+++ b/rust_crate/src/interface_web.rs
@@ -7,21 +7,14 @@ extern "C" {
     pub fn send_rust_signal_extern_raw(
         resource: i32,
         message_bytes: Uint8Array,
-        binary_included: bool,
-        binary_bytes: Uint8Array,
+        binary: Uint8Array,
     );
 }
 
-pub fn send_rust_signal_extern(
-    message_id: i32,
-    message_bytes: Vec<u8>,
-    binary_included: bool,
-    binary_bytes: Vec<u8>,
-) {
+pub fn send_rust_signal_extern(message_id: i32, message_bytes: Vec<u8>, binary: Vec<u8>) {
     send_rust_signal_extern_raw(
         message_id,
         js_sys::Uint8Array::from(message_bytes.as_slice()),
-        binary_included,
-        js_sys::Uint8Array::from(binary_bytes.as_slice()),
+        js_sys::Uint8Array::from(binary.as_slice()),
     );
 }

--- a/rust_crate/src/interface_web.rs
+++ b/rust_crate/src/interface_web.rs
@@ -15,13 +15,13 @@ extern "C" {
 pub fn send_rust_signal_extern(
     message_id: i32,
     message_bytes: Vec<u8>,
-    blob_valid: bool,
-    blob_bytes: Vec<u8>,
+    binary_included: bool,
+    binary_bytes: Vec<u8>,
 ) {
     send_rust_signal_extern_raw(
         message_id,
         js_sys::Uint8Array::from(message_bytes.as_slice()),
-        blob_valid,
-        js_sys::Uint8Array::from(blob_bytes.as_slice()),
+        binary_included,
+        js_sys::Uint8Array::from(binary_bytes.as_slice()),
     );
 }

--- a/rust_crate/src/macros.rs
+++ b/rust_crate/src/macros.rs
@@ -71,19 +71,19 @@ macro_rules! write_interface {
                 message_id: i64,
                 message_pointer: *const u8,
                 message_size: usize,
-                blob_valid: bool,
-                blob_pointer: *const u8,
-                blob_size: usize,
+                binary_included: bool,
+                binary_pointer: *const u8,
+                binary_size: usize,
             ) {
                 let message_bytes = unsafe {
                     Vec::from_raw_parts(message_pointer as *mut u8, message_size, message_size)
                 };
-                let blob = if blob_valid {
+                let binary = if binary_included {
                     unsafe {
                         Some(Vec::from_raw_parts(
-                            blob_pointer as *mut u8,
-                            blob_size,
-                            blob_size,
+                            binary_pointer as *mut u8,
+                            binary_size,
+                            binary_size,
                         ))
                     }
                 } else {
@@ -93,7 +93,7 @@ macro_rules! write_interface {
                     crate::messages::generated::handle_dart_signal(
                         message_id as i32,
                         message_bytes,
-                        blob,
+                        binary,
                     );
                 });
             }
@@ -126,17 +126,21 @@ macro_rules! write_interface {
             pub fn send_dart_signal_extern(
                 message_id: i32,
                 message_bytes: &[u8],
-                blob_valid: bool,
-                blob_bytes: &[u8],
+                binary_included: bool,
+                binary_bytes: &[u8],
             ) {
                 let message_bytes = message_bytes.to_vec();
-                let blob = if blob_valid {
-                    Some(blob_bytes.to_vec())
+                let binary = if binary_included {
+                    Some(binary_bytes.to_vec())
                 } else {
                     None
                 };
                 let _ = catch_unwind(|| {
-                    crate::messages::generated::handle_dart_signal(message_id, message_bytes, blob);
+                    crate::messages::generated::handle_dart_signal(
+                        message_id,
+                        message_bytes,
+                        binary,
+                    );
                 });
             }
         }


### PR DESCRIPTION
## Changes

This PR fixes messages with empty bytes and provide separated binary marks

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_ffi_plugin --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
