### PR TITLE
Avoid using string paths from command code

### DIFF
--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -5,9 +5,9 @@ You can customize some Rinf behaviors by configuring the `pubspec.yaml` file. Ri
 ```yaml title="pubspec.yaml"
 rinf:
   message:
-    input_dir: messages
-    rust_output_dir: native/hub/src/messages
-    dart_output_dir: lib/messages
+    input_dir: messages/
+    rust_output_dir: native/hub/src/messages/
+    dart_output_dir: lib/messages/
 ```
 
 You can check the current configuration status by running the command below in the CLI.

--- a/flutter_ffi_plugin/bin/src/common.dart
+++ b/flutter_ffi_plugin/bin/src/common.dart
@@ -1,0 +1,14 @@
+extension UriJoin on Uri {
+  Uri join(String path) {
+    if (path.isEmpty || path == "/") {
+      // By default, `resolve` method returns root directory
+      // when provided string is empty or a slash.
+      // We need to override this.
+      return this;
+    } else {
+      // If the path is not empty and not a slash,
+      // `resolve` method should handle things properly.
+      return this.resolve(path);
+    }
+  }
+}

--- a/flutter_ffi_plugin/bin/src/config.dart
+++ b/flutter_ffi_plugin/bin/src/config.dart
@@ -48,9 +48,9 @@ class RinfConfigMessage {
   static const KEY_RUST_OUTPUT_DIR = "rust_output_dir";
   static const KEY_DART_OUTPUT_DIR = "dart_output_dir";
 
-  static const DEFAULT_INPUT_DIR = "messages";
-  static const DEFAULT_RUST_OUTPUT_DIR = "native/hub/src/messages";
-  static const DEFAULT_DART_OUTPUT_DIR = "lib/messages";
+  static const DEFAULT_INPUT_DIR = "messages/";
+  static const DEFAULT_RUST_OUTPUT_DIR = "native/hub/src/messages/";
+  static const DEFAULT_DART_OUTPUT_DIR = "lib/messages/";
 
   static const MESSAGE_CONFIG_KEYS = [
     KEY_INPUT_DIR,

--- a/flutter_ffi_plugin/bin/src/helpers.dart
+++ b/flutter_ffi_plugin/bin/src/helpers.dart
@@ -24,9 +24,7 @@ Future<void> applyRustTemplate({
   final packagePath = package.root;
 
   // Check if current folder is a Flutter app project.
-  final specFile = File(
-    flutterProjectPath.join("pubspec.yaml").toFilePath(),
-  );
+  final specFile = File.fromUri(flutterProjectPath.join("pubspec.yaml"));
   final isFlutterProject = await specFile.exists();
   if (!isFlutterProject) {
     print("This folder doesn't look like a Flutter project.");
@@ -58,14 +56,12 @@ Future<void> applyRustTemplate({
 members = ["./native/*"]
 resolver = "2"
 ''';
-  final cargoFile = File(
-    flutterProjectPath.join('Cargo.toml').toFilePath(),
-  );
+  final cargoFile = File.fromUri(flutterProjectPath.join('Cargo.toml'));
   await cargoFile.writeAsString(cargoText);
 
   // Disable demonstrations in sample functions
-  final sampleFunctionsFile = File(
-    flutterProjectPath.join('native/hub/src/sample_functions.rs').toFilePath(),
+  final sampleFunctionsFile = File.fromUri(
+    flutterProjectPath.join('native/hub/src/sample_functions.rs'),
   );
   var sampleFunctionsContent = await sampleFunctionsFile.readAsString();
   sampleFunctionsContent = sampleFunctionsContent.replaceAll(
@@ -77,9 +73,7 @@ resolver = "2"
   // Add some lines to `.gitignore`
   final rustSectionTitle = '# Rust related';
   final messageSectionTitle = '# Generated messages';
-  final gitignoreFile = File(
-    flutterProjectPath.join('.gitignore').toFilePath(),
-  );
+  final gitignoreFile = File.fromUri(flutterProjectPath.join('.gitignore'));
   if (!(await gitignoreFile.exists())) {
     await gitignoreFile.create(recursive: true);
   }
@@ -101,9 +95,7 @@ resolver = "2"
 
   // Add some guides to `README.md`
   final guideSectionTitle = '## Using Rust Inside Flutter';
-  final readmeFile = File(
-    flutterProjectPath.join('README.md').toFilePath(),
-  );
+  final readmeFile = File.fromUri(flutterProjectPath.join('README.md'));
   if (!(await readmeFile.exists())) {
     await readmeFile.create(recursive: true);
   }
@@ -162,9 +154,7 @@ please refer to Rinf's [documentation](https://rinf.cunarist.com).
   await Process.run('dart', ['pub', 'add', 'protobuf']);
 
   // Modify `./lib/main.dart`
-  final mainFile = File(
-    flutterProjectPath.join("lib/main.dart").toFilePath(),
-  );
+  final mainFile = File.fromUri(flutterProjectPath.join("lib/main.dart"));
   if (await mainFile.exists()) {
     await Process.run('dart', ['format', './lib/main.dart']);
     var mainText = await mainFile.readAsString();
@@ -199,13 +189,13 @@ please refer to Rinf's [documentation](https://rinf.cunarist.com).
 }
 
 Future<void> copyDirectory(Uri source, Uri destination) async {
-  final sourceDir = Directory(source.toFilePath());
-  await Directory(destination.toFilePath()).create(recursive: true);
+  final sourceDir = Directory.fromUri(source);
+  await Directory.fromUri(destination).create(recursive: true);
   await for (final entity in sourceDir.list()) {
     final entityName = entity.path.split(Platform.pathSeparator).last;
     if (entity is Directory) {
-      final newDirectory = Directory(
-        destination.join('$entityName/').toFilePath(),
+      final newDirectory = Directory.fromUri(
+        destination.join('$entityName/'),
       );
       await newDirectory.create();
       await copyDirectory(entity.uri, newDirectory.uri);

--- a/flutter_ffi_plugin/bin/src/message.dart
+++ b/flutter_ffi_plugin/bin/src/message.dart
@@ -27,22 +27,21 @@ Future<void> generateMessageCode({
 }) async {
   // Prepare paths.
   final flutterProjectPath = Directory.current;
-  final protoPath =
-      flutterProjectPath.uri.resolve(messageConfig.inputDir).toFilePath();
+  final protoPath = flutterProjectPath.uri.resolve(messageConfig.inputDir);
   final rustOutputPath =
-      flutterProjectPath.uri.resolve(messageConfig.rustOutputDir).toFilePath();
+      flutterProjectPath.uri.resolve(messageConfig.rustOutputDir);
   final dartOutputPath =
-      flutterProjectPath.uri.resolve(messageConfig.dartOutputDir).toFilePath();
-  await Directory(rustOutputPath).create(recursive: true);
-  await emptyDirectory(rustOutputPath);
-  await Directory(dartOutputPath).create(recursive: true);
-  await emptyDirectory(dartOutputPath);
+      flutterProjectPath.uri.resolve(messageConfig.dartOutputDir);
+  await Directory(rustOutputPath.toFilePath()).create(recursive: true);
+  await emptyDirectory(rustOutputPath.toFilePath());
+  await Directory(dartOutputPath.toFilePath()).create(recursive: true);
+  await emptyDirectory(dartOutputPath.toFilePath());
 
   // Get the list of `.proto` files.
   final resourcesInFolders = <String, List<String>>{};
   await collectProtoFiles(
-    Directory(protoPath),
-    Directory(protoPath),
+    Directory(protoPath.toFilePath()),
+    Directory(protoPath.toFilePath()),
     resourcesInFolders,
   );
 
@@ -54,7 +53,9 @@ Future<void> generateMessageCode({
     final subPath = entry.key;
     final resourceNames = entry.value;
     for (final resourceName in resourceNames) {
-      final protoFile = File('$protoPath$subPath/$resourceName.proto');
+      final protoFile = File(
+        protoPath.resolve(subPath).resolve('$resourceName.proto').toFilePath(),
+      );
       final lines = await protoFile.readAsLines();
       List<String> outputLines = [];
       for (var line in lines) {
@@ -89,7 +90,9 @@ Future<void> generateMessageCode({
   for (final entry in resourcesInFolders.entries) {
     final subPath = entry.key;
     final resourceNames = entry.value;
-    await Directory('$rustOutputPath$subPath').create(recursive: true);
+    await Directory(
+      rustOutputPath.resolve(subPath).toFilePath(),
+    ).create(recursive: true);
     if (resourceNames.isEmpty) {
       continue;
     }
@@ -128,7 +131,9 @@ Future<void> generateMessageCode({
       modRsLines.add("pub mod generated;");
     }
     final modRsContent = modRsLines.join('\n');
-    await File('$rustOutputPath$subPath/mod.rs').writeAsString(modRsContent);
+    await File(
+      rustOutputPath.resolve(subPath).resolve('mod.rs').toFilePath(),
+    ).writeAsString(modRsContent);
   }
 
   // Generate Dart message files.
@@ -149,7 +154,9 @@ Future<void> generateMessageCode({
   for (final entry in resourcesInFolders.entries) {
     final subPath = entry.key;
     final resourceNames = entry.value;
-    await Directory('$dartOutputPath$subPath').create(recursive: true);
+    await Directory(
+      dartOutputPath.resolve(subPath).toFilePath(),
+    ).create(recursive: true);
     if (resourceNames.isEmpty) {
       continue;
     }
@@ -416,7 +423,9 @@ hash_map.insert(
     signal_handler(message_bytes, binary);
 }
 ''';
-  await File('$rustOutputPath/generated.rs').writeAsString(rustReceiveScript);
+  await File(
+    rustOutputPath.resolve('generated.rs').toFilePath(),
+  ).writeAsString(rustReceiveScript);
 
   // Get ready to handle received signals in Dart.
   var dartReceiveScript = "";
@@ -478,7 +487,9 @@ void handleRustSignal(int messageId, Uint8List messageBytes, Uint8List binary) {
   signalHandlers[messageId]!(messageBytes, binary);
 }
 ''';
-  await File('$dartOutputPath/generated.dart').writeAsString(dartReceiveScript);
+  await File(
+    dartOutputPath.resolve('generated.dart').toFilePath(),
+  ).writeAsString(dartReceiveScript);
 
   // Notify that it's done
   if (!silent) {
@@ -655,7 +666,7 @@ Future<void> insertTextToFile(
 }
 
 Future<Map<String, Map<String, List<MarkedMessage>>>> analyzeMarkedMessages(
-  String protoPath,
+  Uri protoPath,
   Map<String, List<String>> resourcesInFolders,
 ) async {
   final markedMessages = <String, Map<String, List<MarkedMessage>>>{};
@@ -672,7 +683,9 @@ Future<Map<String, Map<String, List<MarkedMessage>>>> analyzeMarkedMessages(
   for (final entry in resourcesInFolders.entries) {
     final subpath = entry.key;
     for (final filename in entry.value) {
-      final protoFile = File('$protoPath/$subpath/$filename.proto');
+      final protoFile = File(
+        protoPath.resolve(subpath).resolve('$filename.proto').toFilePath(),
+      );
       final content = await protoFile.readAsString();
       final regExp = RegExp(r'{[^}]*}');
       // Remove all { ... } blocks from the string

--- a/flutter_ffi_plugin/bin/src/message.dart
+++ b/flutter_ffi_plugin/bin/src/message.dart
@@ -33,16 +33,16 @@ Future<void> generateMessageCode({
       flutterProjectPath.uri.join(messageConfig.rustOutputDir);
   final dartOutputPath =
       flutterProjectPath.uri.join(messageConfig.dartOutputDir);
-  await Directory(rustOutputPath.toFilePath()).create(recursive: true);
-  await emptyDirectory(rustOutputPath.toFilePath());
-  await Directory(dartOutputPath.toFilePath()).create(recursive: true);
-  await emptyDirectory(dartOutputPath.toFilePath());
+  await Directory.fromUri(rustOutputPath).create(recursive: true);
+  await emptyDirectory(rustOutputPath);
+  await Directory.fromUri(dartOutputPath).create(recursive: true);
+  await emptyDirectory(dartOutputPath);
 
   // Get the list of `.proto` files.
   final resourcesInFolders = <String, List<String>>{};
   await collectProtoFiles(
-    Directory(protoPath.toFilePath()),
-    Directory(protoPath.toFilePath()),
+    Directory.fromUri(protoPath),
+    Directory.fromUri(protoPath),
     resourcesInFolders,
   );
 
@@ -54,8 +54,8 @@ Future<void> generateMessageCode({
     final subPath = entry.key;
     final resourceNames = entry.value;
     for (final resourceName in resourceNames) {
-      final protoFile = File(
-        protoPath.join(subPath).join('$resourceName.proto').toFilePath(),
+      final protoFile = File.fromUri(
+        protoPath.join(subPath).join('$resourceName.proto'),
       );
       final lines = await protoFile.readAsLines();
       List<String> outputLines = [];
@@ -92,9 +92,8 @@ Future<void> generateMessageCode({
     final subPath = entry.key;
     final resourceNames = entry.value;
     if (subPath.isNotEmpty) {
-      await Directory(
-        rustOutputPath.join(subPath).toFilePath(),
-      ).create(recursive: true);
+      await Directory.fromUri(rustOutputPath.join(subPath))
+          .create(recursive: true);
     }
     if (resourceNames.isEmpty) {
       continue;
@@ -160,9 +159,8 @@ Future<void> generateMessageCode({
       modRsLines.add("pub mod generated;");
     }
     final modRsContent = modRsLines.join('\n');
-    await File(
-      rustOutputPath.join(subPath).join('mod.rs').toFilePath(),
-    ).writeAsString(modRsContent);
+    await File.fromUri(rustOutputPath.join(subPath).join('mod.rs'))
+        .writeAsString(modRsContent);
   }
 
   // Generate Dart message files.
@@ -184,9 +182,8 @@ Future<void> generateMessageCode({
     final subPath = entry.key;
     final resourceNames = entry.value;
     if (subPath.isNotEmpty) {
-      await Directory(
-        dartOutputPath.join(subPath).toFilePath(),
-      ).create(recursive: true);
+      await Directory.fromUri(dartOutputPath.join(subPath))
+          .create(recursive: true);
     }
     if (resourceNames.isEmpty) {
       continue;
@@ -457,9 +454,8 @@ hash_map.insert(
     signal_handler(message_bytes, binary);
 }
 ''';
-  await File(
-    rustOutputPath.join('generated.rs').toFilePath(),
-  ).writeAsString(rustReceiveScript);
+  await File.fromUri(rustOutputPath.join('generated.rs'))
+      .writeAsString(rustReceiveScript);
 
   // Get ready to handle received signals in Dart.
   var dartReceiveScript = "";
@@ -523,9 +519,8 @@ void handleRustSignal(int messageId, Uint8List messageBytes, Uint8List binary) {
   signalHandlers[messageId]!(messageBytes, binary);
 }
 ''';
-  await File(
-    dartOutputPath.join('generated.dart').toFilePath(),
-  ).writeAsString(dartReceiveScript);
+  await File.fromUri(dartOutputPath.join('generated.dart'))
+      .writeAsString(dartReceiveScript);
 
   // Notify that it's done
   if (!silent) {
@@ -662,8 +657,8 @@ Future<void> collectProtoFiles(
   resourcesInFolders[subPath] = resources;
 }
 
-Future<void> emptyDirectory(String directoryPath) async {
-  final directory = Directory(directoryPath);
+Future<void> emptyDirectory(Uri directoryPath) async {
+  final directory = Directory.fromUri(directoryPath);
 
   if (await directory.exists()) {
     await for (final entity in directory.list()) {
@@ -720,8 +715,8 @@ Future<Map<String, Map<String, List<MarkedMessage>>>> analyzeMarkedMessages(
   for (final entry in resourcesInFolders.entries) {
     final subPath = entry.key;
     for (final filename in entry.value) {
-      final protoFile = File(
-        protoPath.join(subPath).join('$filename.proto').toFilePath(),
+      final protoFile = File.fromUri(
+        protoPath.join(subPath).join('$filename.proto'),
       );
       final content = await protoFile.readAsString();
       final regExp = RegExp(r'{[^}]*}');

--- a/flutter_ffi_plugin/bin/src/message.dart
+++ b/flutter_ffi_plugin/bin/src/message.dart
@@ -91,10 +91,8 @@ Future<void> generateMessageCode({
   for (final entry in resourcesInFolders.entries) {
     final subPath = entry.key;
     final resourceNames = entry.value;
-    if (subPath.isNotEmpty) {
-      await Directory.fromUri(rustOutputPath.join(subPath))
-          .create(recursive: true);
-    }
+    await Directory.fromUri(rustOutputPath.join(subPath))
+        .create(recursive: true);
     if (resourceNames.isEmpty) {
       continue;
     }
@@ -181,10 +179,8 @@ Future<void> generateMessageCode({
   for (final entry in resourcesInFolders.entries) {
     final subPath = entry.key;
     final resourceNames = entry.value;
-    if (subPath.isNotEmpty) {
-      await Directory.fromUri(dartOutputPath.join(subPath))
-          .create(recursive: true);
-    }
+    await Directory.fromUri(dartOutputPath.join(subPath))
+        .create(recursive: true);
     if (resourceNames.isEmpty) {
       continue;
     }


### PR DESCRIPTION
## Changes

With Flutter 3.22, path resolution for directories and files has became more strict. This PR replaces `String` paths with `Uri` paths. 

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_ffi_plugin --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
