### PR TITLE
Manage memory in the language itself

### DIFF
--- a/flutter_ffi_plugin/lib/src/interface_os.dart
+++ b/flutter_ffi_plugin/lib/src/interface_os.dart
@@ -98,9 +98,9 @@ Future<void> sendDartSignalExtern(
 
   rustFunction(
     messageId,
-    messageMemory.cast(),
+    messageMemory,
     messageBytes.length,
-    binaryMemory.cast(),
+    binaryMemory,
     binary.length,
   );
 

--- a/flutter_ffi_plugin/lib/src/interface_os.dart
+++ b/flutter_ffi_plugin/lib/src/interface_os.dart
@@ -104,11 +104,8 @@ Future<void> sendDartSignalExtern(
     binary.length,
   );
 
-  // Note that we do not free memory here with `malloc.free()`,
-  // because Rust will take the ownership of the memory space
-  // with `Vec::from_raw_parts()`.
-  // Rust will properly deallocate the memory later
-  // when `Vec<u8>` is dropped.
+  malloc.free(messageMemory);
+  malloc.free(binaryMemory);
 }
 
 void prepareIsolateExtern(int port) {

--- a/rust_crate/src/macros.rs
+++ b/rust_crate/src/macros.rs
@@ -75,10 +75,10 @@ macro_rules! write_interface {
                 binary_size: usize,
             ) {
                 let message_bytes = unsafe {
-                    Vec::from_raw_parts(message_pointer as *mut u8, message_size, message_size)
+                    std::slice::from_raw_parts(message_pointer as *mut u8, message_size).to_vec()
                 };
                 let binary = unsafe {
-                    Vec::from_raw_parts(binary_pointer as *mut u8, binary_size, binary_size)
+                    std::slice::from_raw_parts(binary_pointer as *mut u8, binary_size).to_vec()
                 };
                 let _ = catch_unwind(|| {
                     crate::messages::generated::handle_dart_signal(


### PR DESCRIPTION
## Changes

Before, Rust was in charge of freeing the memory allocated from Dart. However, for extra-clear memory safety, freeing the memory from Dart can be better.

- https://doc.rust-lang.org/std/vec/struct.Vec.html#method.from_raw_parts

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_ffi_plugin --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
