### PR TITLE
feat(message): enable usage of the protoc-gen-prost-serde plugin

### DIFF
--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -8,6 +8,7 @@ rinf:
     input_dir: messages/
     rust_output_dir: native/hub/src/messages/
     dart_output_dir: lib/messages/
+    rust_serde: true
 ```
 
 You can check the current configuration status by running the command below in the CLI.

--- a/flutter_ffi_plugin/bin/src/config.dart
+++ b/flutter_ffi_plugin/bin/src/config.dart
@@ -117,6 +117,7 @@ rinf:
 ///     input_dir: messages
 ///     rust_output_dir: native/hub/src/messages
 ///     dart_output_dir: lib/messages
+///     rust_serde: true
 /// ```
 Future<RinfConfig> loadVerifiedRinfConfig(String pubspecYamlFile) async {
   final pubspec = loadYaml(await File(pubspecYamlFile).readAsString());

--- a/flutter_ffi_plugin/bin/src/config.dart
+++ b/flutter_ffi_plugin/bin/src/config.dart
@@ -5,19 +5,21 @@ class RinfConfigMessage {
   final String inputDir;
   final String rustOutputDir;
   final String dartOutputDir;
+  final bool rustSerde;
 
   RinfConfigMessage({
     required this.inputDir,
     required this.rustOutputDir,
     required this.dartOutputDir,
+    required this.rustSerde,
   });
 
   factory RinfConfigMessage.defaultConfig() {
     return RinfConfigMessage(
-      inputDir: DEFAULT_INPUT_DIR,
-      rustOutputDir: DEFAULT_RUST_OUTPUT_DIR,
-      dartOutputDir: DEFAULT_DART_OUTPUT_DIR,
-    );
+        inputDir: DEFAULT_INPUT_DIR,
+        rustOutputDir: DEFAULT_RUST_OUTPUT_DIR,
+        dartOutputDir: DEFAULT_DART_OUTPUT_DIR,
+        rustSerde: DEFAULT_RUST_SERDE);
   }
 
   factory RinfConfigMessage.from(YamlMap yaml) {
@@ -33,6 +35,7 @@ class RinfConfigMessage {
       inputDir: yaml[KEY_INPUT_DIR] ?? DEFAULT_INPUT_DIR,
       rustOutputDir: yaml[KEY_RUST_OUTPUT_DIR] ?? DEFAULT_RUST_OUTPUT_DIR,
       dartOutputDir: yaml[KEY_DART_OUTPUT_DIR] ?? DEFAULT_DART_OUTPUT_DIR,
+      rustSerde: yaml[KEY_RUST_SERDE] ?? DEFAULT_RUST_SERDE,
     );
   }
 
@@ -47,15 +50,18 @@ class RinfConfigMessage {
   static const KEY_INPUT_DIR = "input_dir";
   static const KEY_RUST_OUTPUT_DIR = "rust_output_dir";
   static const KEY_DART_OUTPUT_DIR = "dart_output_dir";
+  static const KEY_RUST_SERDE = "rust_serde";
 
   static const DEFAULT_INPUT_DIR = "messages/";
   static const DEFAULT_RUST_OUTPUT_DIR = "native/hub/src/messages/";
   static const DEFAULT_DART_OUTPUT_DIR = "lib/messages/";
+  static const DEFAULT_RUST_SERDE = false;
 
   static const MESSAGE_CONFIG_KEYS = [
     KEY_INPUT_DIR,
     KEY_RUST_OUTPUT_DIR,
     KEY_DART_OUTPUT_DIR,
+    KEY_RUST_SERDE
   ];
 }
 

--- a/flutter_ffi_plugin/bin/src/config.dart
+++ b/flutter_ffi_plugin/bin/src/config.dart
@@ -16,10 +16,11 @@ class RinfConfigMessage {
 
   factory RinfConfigMessage.defaultConfig() {
     return RinfConfigMessage(
-        inputDir: DEFAULT_INPUT_DIR,
-        rustOutputDir: DEFAULT_RUST_OUTPUT_DIR,
-        dartOutputDir: DEFAULT_DART_OUTPUT_DIR,
-        rustSerde: DEFAULT_RUST_SERDE);
+      inputDir: DEFAULT_INPUT_DIR,
+      rustOutputDir: DEFAULT_RUST_OUTPUT_DIR,
+      dartOutputDir: DEFAULT_DART_OUTPUT_DIR,
+      rustSerde: DEFAULT_RUST_SERDE,
+    );
   }
 
   factory RinfConfigMessage.from(YamlMap yaml) {

--- a/flutter_ffi_plugin/bin/src/message.dart
+++ b/flutter_ffi_plugin/bin/src/message.dart
@@ -83,6 +83,7 @@ Future<void> generateMessageCode({
   final cargoInstallCommand = await Process.run('cargo', [
     'install',
     'protoc-gen-prost',
+    ...(messageConfig.rustSerde ? ['protoc-gen-prost-serde'] : [])
   ]);
   if (cargoInstallCommand.exitCode != 0) {
     print(cargoInstallCommand.stderr.toString().trim());
@@ -105,6 +106,7 @@ Future<void> generateMessageCode({
     final protocRustResult = await Process.run('protoc', [
       ...protoPaths,
       '--prost_out=$rustFullPath',
+      ...(messageConfig.rustSerde ? ['--prost-serde_out=$rustFullPath'] : []),
       ...resourceNames.map((name) => '$name.proto'),
     ]);
     if (protocRustResult.exitCode != 0) {


### PR DESCRIPTION
## Changes

Optionally install and use a protoc plugin that generates serde serialization implementations that follow the conventions of protobuf-JSON for Rust. This is useful for storing messages at rest, and prevents having to re-implement similar data structures or continually updating the output implementations every time `message` re-creates them. This is common when wishing to store messages with storage mechanisms, such as databases, or passing the data to HTTP servers which might require serialization.

Thank you in advance for any assistance you could provide. There is little if any information floating around about how to set up and work with this project as a contributor or developer, and my familiarity with the project at this point is minimal, so honestly these changes are completely un-tested.