### PR TITLE
Remove `RefCell` from generated code

### DIFF
--- a/flutter_ffi_plugin/bin/src/message.dart
+++ b/flutter_ffi_plugin/bin/src/message.dart
@@ -250,7 +250,6 @@ use crate::tokio;
 use prost::Message;
 use rinf::send_rust_signal;
 use rinf::DartSignal;
-use rinf::SharedLock;
 use std::sync::Mutex;
 use std::sync::OnceLock;
 use tokio::sync::mpsc::unbounded_channel;
@@ -271,10 +270,10 @@ use tokio::sync::mpsc::UnboundedSender;
           await insertTextToFile(
             rustPath,
             '''
-type ${messageName}Cell = SharedLock<(
+type ${messageName}Cell = OnceLock<Mutex<Option<(
     Option<UnboundedSender<DartSignal<${normalizePascal(messageName)}>>>,
     Option<UnboundedReceiver<DartSignal<${normalizePascal(messageName)}>>>,
-)>;
+)>>>;
 pub static ${snakeName.toUpperCase()}_CHANNEL: ${messageName}Cell =
     OnceLock::new();
 

--- a/flutter_ffi_plugin/bin/src/message.dart
+++ b/flutter_ffi_plugin/bin/src/message.dart
@@ -280,7 +280,7 @@ pub static ${snakeName.toUpperCase()}_CHANNEL: ${messageName}Cell =
 
 impl ${normalizePascal(messageName)} {
     pub fn get_dart_signal_receiver() -> UnboundedReceiver<DartSignal<Self>> {
-        let mut lock = ${snakeName.toUpperCase()}_CHANNEL
+        let mut guard = ${snakeName.toUpperCase()}_CHANNEL
             .get_or_init(|| {
                 let (sender, receiver) = unbounded_channel();
                 Mutex::new(Some((Some(sender), Some(receiver))))
@@ -292,15 +292,15 @@ impl ${normalizePascal(messageName)} {
             // After Dart's hot restart,
             // a sender from the previous run already exists
             // which is now closed.
-            let pair = lock.as_ref().unwrap();
+            let pair = guard.as_ref().unwrap();
             let is_closed = pair.0.as_ref().unwrap().is_closed();
             if is_closed {
                 let (sender, receiver) = unbounded_channel();
-                lock.replace((Some(sender), Some(receiver)));
+                guard.replace((Some(sender), Some(receiver)));
             }
         }
-        let pair = lock.take().unwrap();
-        lock.replace((pair.0, None));
+        let pair = guard.take().unwrap();
+        guard.replace((pair.0, None));
         pair.1.expect("A receiver can be taken only once")
     }
 }
@@ -448,7 +448,7 @@ hash_map.insert(
             message,
             binary,
         };
-        let mut lock = ${snakeName.toUpperCase()}_CHANNEL
+        let mut guard = ${snakeName.toUpperCase()}_CHANNEL
             .get_or_init(|| {
                 let (sender, receiver) = unbounded_channel();
                 Mutex::new(Some((Some(sender), Some(receiver))))
@@ -460,14 +460,14 @@ hash_map.insert(
             // After Dart's hot restart,
             // a sender from the previous run already exists
             // which is now closed.
-            let pair = lock.as_ref().unwrap();
+            let pair = guard.as_ref().unwrap();
             let is_closed = pair.0.as_ref().unwrap().is_closed();
             if is_closed {
                 let (sender, receiver) = unbounded_channel();
-                lock.replace((Some(sender), Some(receiver)));
+                guard.replace((Some(sender), Some(receiver)));
             }
         }
-        let pair = lock.as_ref().unwrap();
+        let pair = guard.as_ref().unwrap();
         let sender = pair.0.as_ref().unwrap();
         let _ = sender.send(dart_signal);
     }),

--- a/rust_crate/src/interface.rs
+++ b/rust_crate/src/interface.rs
@@ -1,4 +1,3 @@
-use std::cell::RefCell;
 use std::sync::Mutex;
 use std::sync::OnceLock;
 
@@ -8,7 +7,7 @@ use super::interface_os::*;
 use super::interface_web::*;
 
 /// This is a mutable cell type that can be shared across threads.
-pub type SharedCell<T> = OnceLock<Mutex<RefCell<Option<T>>>>;
+pub type SharedLock<T> = OnceLock<Mutex<Option<T>>>;
 
 /// This contains a message from Dart.
 /// Optionally, a custom binary called `binary` can also be included.

--- a/rust_crate/src/interface.rs
+++ b/rust_crate/src/interface.rs
@@ -1,13 +1,7 @@
-use std::sync::Mutex;
-use std::sync::OnceLock;
-
 #[cfg(not(target_family = "wasm"))]
 use super::interface_os::*;
 #[cfg(target_family = "wasm")]
 use super::interface_web::*;
-
-/// This is a mutable cell type that can be shared across threads.
-pub type SharedLock<T> = OnceLock<Mutex<Option<T>>>;
 
 /// This contains a message from Dart.
 /// Optionally, a custom binary called `binary` can also be included.

--- a/rust_crate/src/interface_os.rs
+++ b/rust_crate/src/interface_os.rs
@@ -12,11 +12,11 @@ static DART_ISOLATE: SharedLock<Isolate> = OnceLock::new();
 pub extern "C" fn prepare_isolate_extern(port: i64) {
     let _ = catch_unwind(|| {
         let dart_isolate = Isolate::new(port);
-        let mut cell = DART_ISOLATE
+        let mut guard = DART_ISOLATE
             .get_or_init(|| Mutex::new(None))
             .lock()
             .unwrap();
-        cell.replace(dart_isolate);
+        guard.replace(dart_isolate);
     });
 }
 

--- a/rust_crate/src/interface_os.rs
+++ b/rust_crate/src/interface_os.rs
@@ -1,4 +1,3 @@
-use super::SharedLock;
 use allo_isolate::IntoDart;
 use allo_isolate::Isolate;
 use allo_isolate::ZeroCopyBuffer;
@@ -6,7 +5,7 @@ use std::panic::catch_unwind;
 use std::sync::Mutex;
 use std::sync::OnceLock;
 
-static DART_ISOLATE: SharedLock<Isolate> = OnceLock::new();
+static DART_ISOLATE: OnceLock<Mutex<Option<Isolate>>> = OnceLock::new();
 
 #[no_mangle]
 pub extern "C" fn prepare_isolate_extern(port: i64) {


### PR DESCRIPTION
## Changes

This PR makes code generator produce cleaner code

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_ffi_plugin --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
