### PR TITLE
Remove linter warnings in wasm and release mode

### DIFF
--- a/.github/workflows/quality_control.yaml
+++ b/.github/workflows/quality_control.yaml
@@ -58,10 +58,10 @@ jobs:
         run: |
           rustup target add wasm32-unknown-unknown
           RUSTFLAGS="-D warnings"
-          cargo check
-          cargo check --release
-          cargo check --target wasm32-unknown-unknown
-          cargo check --target wasm32-unknown-unknown --release
+          cargo clippy
+          cargo clippy --release
+          cargo clippy --target wasm32-unknown-unknown
+          cargo clippy --target wasm32-unknown-unknown --release
 
       - name: Analyze code
         run: |

--- a/.github/workflows/quality_control.yaml
+++ b/.github/workflows/quality_control.yaml
@@ -23,6 +23,8 @@ jobs:
   code:
     name: dart-and-rust-code
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/quality_control.yaml
+++ b/.github/workflows/quality_control.yaml
@@ -57,7 +57,6 @@ jobs:
       - name: Check for any errors
         run: |
           rustup target add wasm32-unknown-unknown
-          RUSTFLAGS="-D warnings"
           cargo clippy
           cargo clippy --release
           cargo clippy --target wasm32-unknown-unknown

--- a/rust_crate/src/interface_os.rs
+++ b/rust_crate/src/interface_os.rs
@@ -1,6 +1,5 @@
 use crate::debug_print;
 use allo_isolate::{IntoDart, Isolate, ZeroCopyBuffer};
-use backtrace::Backtrace;
 use os_thread_local::ThreadLocal;
 use std::cell::RefCell;
 use std::future::Future;
@@ -35,7 +34,7 @@ where
     #[cfg(debug_assertions)]
     {
         std::panic::set_hook(Box::new(|panic_info| {
-            let backtrace = Backtrace::new();
+            let backtrace = backtrace::Backtrace::new();
             debug_print!("A panic occurred in Rust.\n{panic_info}\n{backtrace:?}");
         }));
     }

--- a/rust_crate/src/interface_web.rs
+++ b/rust_crate/src/interface_web.rs
@@ -1,4 +1,3 @@
-use crate::debug_print;
 use js_sys::Uint8Array;
 use std::future::Future;
 use wasm_bindgen::prelude::*;
@@ -12,7 +11,7 @@ where
     #[cfg(debug_assertions)]
     {
         std::panic::set_hook(Box::new(|panic_info| {
-            debug_print!("A panic occurred in Rust.\n{panic_info}");
+            crate::debug_print!("A panic occurred in Rust.\n{panic_info}");
         }));
     }
 

--- a/rust_crate/src/macros.rs
+++ b/rust_crate/src/macros.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::crate_in_macro_def)]
-
 #[macro_export]
 /// Writes the interface code
 /// needed to communicate with Dart.

--- a/rust_crate/src/macros.rs
+++ b/rust_crate/src/macros.rs
@@ -19,7 +19,7 @@ macro_rules! write_interface {
 
         #[cfg(not(target_family = "wasm"))]
         #[no_mangle]
-        pub extern "C" fn send_dart_signal_extern(
+        pub unsafe extern "C" fn send_dart_signal_extern(
             message_id: i64,
             message_pointer: *const u8,
             message_size: usize,


### PR DESCRIPTION
## Changes

This PR simply organizes code

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_ffi_plugin --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
