### PR TITLE
Remove all code that can possibly panic

### DIFF
--- a/flutter_ffi_plugin/bin/src/message.dart
+++ b/flutter_ffi_plugin/bin/src/message.dart
@@ -295,7 +295,7 @@ impl ${normalizePascal(messageName)} {
             }
         }
         let pair = guard
-            .as_ref()
+            .take()
             .expect("Message channel in Rust not present.");
         guard.replace((pair.0, None));
         pair.1.expect("Each Dart signal receiver can be taken only once")

--- a/flutter_ffi_plugin/example/native/sample_crate/src/lib.rs
+++ b/flutter_ffi_plugin/example/native/sample_crate/src/lib.rs
@@ -4,7 +4,6 @@ mod fractal;
 pub use fractal::draw_fractal_image;
 
 // `machineid_rs` only supports desktop platforms.
-
 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 pub fn get_hardward_id() -> Option<String> {
     let mut builder = machineid_rs::IdBuilder::new(machineid_rs::Encryption::MD5);
@@ -20,14 +19,12 @@ pub fn get_hardward_id() -> Option<String> {
 }
 
 // `chrono` supports all platforms, including web.
-
 use chrono::{offset, DateTime};
 pub fn get_current_time() -> DateTime<offset::Local> {
     offset::Local::now()
 }
 
 // `reqwest` supports all platforms, including web.
-
 pub async fn fetch_from_web_api(url: &str) -> Option<String> {
     reqwest::get(url).await.ok()?.text().await.ok()
 }

--- a/flutter_ffi_plugin/example/native/sample_crate/src/lib.rs
+++ b/flutter_ffi_plugin/example/native/sample_crate/src/lib.rs
@@ -1,8 +1,7 @@
 //! This crate is written for Rinf demonstrations.
 
-pub use fractal::draw_fractal_image;
-
 mod fractal;
+pub use fractal::draw_fractal_image;
 
 // `machineid_rs` only supports desktop platforms.
 
@@ -12,7 +11,7 @@ pub fn get_hardward_id() -> Option<String> {
     builder
         .add_component(machineid_rs::HWIDComponent::SystemID)
         .add_component(machineid_rs::HWIDComponent::CPUCores);
-    let hwid = builder.build("mykey").unwrap();
+    let hwid = builder.build("mykey").ok()?;
     Some(hwid)
 }
 #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
@@ -29,11 +28,6 @@ pub fn get_current_time() -> DateTime<offset::Local> {
 
 // `reqwest` supports all platforms, including web.
 
-pub async fn fetch_from_web_api(url: &str) -> String {
-    reqwest::get(url)
-        .await
-        .expect("Could not get the response from the example web API.")
-        .text()
-        .await
-        .expect("Could not read body from the web response.")
+pub async fn fetch_from_web_api(url: &str) -> Option<String> {
+    reqwest::get(url).await.ok()?.text().await.ok()
 }

--- a/rust_crate/src/common.rs
+++ b/rust_crate/src/common.rs
@@ -1,0 +1,3 @@
+use std::error::Error;
+
+pub type Result<T> = std::result::Result<T, Box<dyn Error>>;

--- a/rust_crate/src/interface.rs
+++ b/rust_crate/src/interface.rs
@@ -1,4 +1,4 @@
-use crate::debug_print;
+use crate::common::*;
 use std::future::Future;
 
 #[cfg(not(target_family = "wasm"))]
@@ -20,14 +20,11 @@ pub struct DartSignal<T> {
 }
 
 /// Runs the main function in Rust.
-pub fn start_rust_logic<F>(main_future: F)
+pub fn start_rust_logic<F>(main_future: F) -> Result<()>
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    let result = start_rust_logic_real(main_future);
-    if let Err(error) = result {
-        debug_print!("Could not start Rust logic.\n{error:#?}");
-    }
+    start_rust_logic_real(main_future)
 }
 
 /// Send a signal to Dart.

--- a/rust_crate/src/interface.rs
+++ b/rust_crate/src/interface.rs
@@ -1,3 +1,4 @@
+use crate::debug_print;
 use std::future::Future;
 
 #[cfg(not(target_family = "wasm"))]
@@ -18,15 +19,23 @@ pub struct DartSignal<T> {
     pub binary: Vec<u8>,
 }
 
-/// Send a signal to Dart.
-pub fn send_rust_signal(message_id: i32, message_bytes: Vec<u8>, binary: Vec<u8>) {
-    send_rust_signal_real(message_id, message_bytes, binary);
-}
-
 /// Runs the main function in Rust.
 pub fn start_rust_logic<F>(main_future: F)
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    start_rust_logic_real(main_future);
+    let result = start_rust_logic_real(main_future);
+    if let Err(error) = result {
+        debug_print!("Could not start Rust logic.\n{error:#?}");
+    }
+}
+
+/// Send a signal to Dart.
+pub fn send_rust_signal(message_id: i32, message_bytes: Vec<u8>, binary: Vec<u8>) {
+    let result = send_rust_signal_real(message_id, message_bytes, binary);
+    if let Err(error) = result {
+        // We cannot use `debug_print` here because
+        // it uses `send_rust_siganl` internally.
+        println!("Could not send Rust signal.\n{error:#?}");
+    }
 }

--- a/rust_crate/src/interface_os.rs
+++ b/rust_crate/src/interface_os.rs
@@ -1,5 +1,4 @@
 use crate::common::*;
-use crate::debug_print;
 use allo_isolate::{IntoDart, Isolate, ZeroCopyBuffer};
 use os_thread_local::ThreadLocal;
 use std::cell::RefCell;
@@ -39,7 +38,7 @@ where
     {
         std::panic::set_hook(Box::new(|panic_info| {
             let backtrace = backtrace::Backtrace::new();
-            debug_print!("A panic occurred in Rust.\n{panic_info}\n{backtrace:?}");
+            crate::debug_print!("A panic occurred in Rust.\n{panic_info}\n{backtrace:?}");
         }));
     }
 

--- a/rust_crate/src/interface_web.rs
+++ b/rust_crate/src/interface_web.rs
@@ -1,9 +1,10 @@
+use crate::common::*;
 use js_sys::Uint8Array;
 use std::future::Future;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::spawn_local;
 
-pub fn start_rust_logic_real<F>(main_future: F)
+pub fn start_rust_logic_real<F>(main_future: F) -> Result<()>
 where
     F: Future<Output = ()> + Send + 'static,
 {
@@ -17,6 +18,8 @@ where
 
     // Run the main function.
     spawn_local(main_future);
+
+    Ok(())
 }
 
 #[wasm_bindgen]
@@ -25,10 +28,16 @@ extern "C" {
     pub fn send_rust_signal_extern(resource: i32, message_bytes: Uint8Array, binary: Uint8Array);
 }
 
-pub fn send_rust_signal_real(message_id: i32, message_bytes: Vec<u8>, binary: Vec<u8>) {
+pub fn send_rust_signal_real(
+    message_id: i32,
+    message_bytes: Vec<u8>,
+    binary: Vec<u8>,
+) -> Result<()> {
     send_rust_signal_extern(
         message_id,
         js_sys::Uint8Array::from(message_bytes.as_slice()),
         js_sys::Uint8Array::from(binary.as_slice()),
     );
+
+    Ok(())
 }

--- a/rust_crate/src/lib.rs
+++ b/rust_crate/src/lib.rs
@@ -1,3 +1,4 @@
+mod common;
 mod macros;
 
 mod interface;

--- a/rust_crate/src/macros.rs
+++ b/rust_crate/src/macros.rs
@@ -8,13 +8,19 @@ macro_rules! write_interface {
         #[cfg(not(target_family = "wasm"))]
         #[no_mangle]
         pub extern "C" fn start_rust_logic_extern() {
-            let _ = std::panic::catch_unwind(|| $crate::start_rust_logic(main()));
+            let result = $crate::start_rust_logic(main());
+            if let Err(error) = result {
+                println!("Could not start Rust logic.\n{error:#?}");
+            }
         }
 
         #[cfg(target_family = "wasm")]
         #[wasm_bindgen::prelude::wasm_bindgen]
         pub fn start_rust_logic_extern() {
-            let _ = std::panic::catch_unwind(|| $crate::start_rust_logic(main()));
+            let result = $crate::start_rust_logic(main());
+            if let Err(error) = result {
+                println!("Could not start Rust logic.\n{error:#?}");
+            }
         }
 
         #[cfg(not(target_family = "wasm"))]
@@ -26,23 +32,19 @@ macro_rules! write_interface {
             binary_pointer: *const u8,
             binary_size: usize,
         ) {
-            let _ = std::panic::catch_unwind(|| {
-                let message_bytes =
-                    unsafe { std::slice::from_raw_parts(message_pointer, message_size).to_vec() };
-                let binary =
-                    unsafe { std::slice::from_raw_parts(binary_pointer, binary_size).to_vec() };
-                messages::generated::handle_dart_signal(message_id as i32, message_bytes, binary);
-            });
+            let message_bytes =
+                unsafe { std::slice::from_raw_parts(message_pointer, message_size).to_vec() };
+            let binary =
+                unsafe { std::slice::from_raw_parts(binary_pointer, binary_size).to_vec() };
+            messages::generated::handle_dart_signal(message_id as i32, message_bytes, binary);
         }
 
         #[cfg(target_family = "wasm")]
         #[wasm_bindgen::prelude::wasm_bindgen]
         pub fn send_dart_signal_extern(message_id: i32, message_bytes: &[u8], binary: &[u8]) {
-            let _ = std::panic::catch_unwind(|| {
-                let message_bytes = message_bytes.to_vec();
-                let binary = binary.to_vec();
-                messages::generated::handle_dart_signal(message_id, message_bytes, binary);
-            });
+            let message_bytes = message_bytes.to_vec();
+            let binary = binary.to_vec();
+            messages::generated::handle_dart_signal(message_id, message_bytes, binary);
         }
     };
 }

--- a/rust_crate/src/main.rs
+++ b/rust_crate/src/main.rs
@@ -1,39 +1,55 @@
+mod common;
+use common::*;
+
 #[cfg(not(target_family = "wasm"))]
-fn main() {
+fn main() -> Result<()> {
     use std::env;
     use std::fs;
     use std::path;
     use std::process;
 
     // Verify Protobuf compiler.
-    let protoc_path;
-    if let Ok(installed) = which::which("protoc") {
+    let protoc_path = if let Ok(installed) = which::which("protoc") {
         // Get the path of Protobuf compiler that's already installed.
         println!("Detected `protoc`, skipping auto installation.");
-        protoc_path = installed.parent().unwrap().to_path_buf();
+        installed
+            .parent()
+            .ok_or("Could not get the parent of `protoc` path.")?
+            .to_path_buf()
     } else {
         // Install Protobuf compiler and get the path.
-        let home_path = home::home_dir().unwrap();
+        let home_path =
+            home::home_dir().ok_or("Could not get home directory for `protoc` installation.")?;
         let out_path = home_path.join(".local").join("bin");
-        fs::create_dir_all(&out_path).unwrap();
-        env::set_var("OUT_DIR", out_path.to_str().unwrap());
+        fs::create_dir_all(&out_path)?;
+        env::set_var(
+            "OUT_DIR",
+            out_path
+                .to_str()
+                .ok_or("Could not set environment variable path")?,
+        );
         let install_result = protoc_prebuilt::init("25.2");
-        if install_result.is_err() {
-            println!("Automatic installation of `protoc` failed.");
-            println!("Try installing `protoc` manually and adding it to PATH.");
-        }
-        let (protoc_binary_path, _) = install_result.unwrap();
-        protoc_path = protoc_binary_path.parent().unwrap().to_path_buf();
-    }
+        let (protoc_binary_path, _) = install_result.map_err(|_| {
+            format!(
+                "{}\n{}",
+                "Automatic installation of `protoc` failed.",
+                "Try installing `protoc` manually and adding it to PATH."
+            )
+        })?;
+        protoc_binary_path
+            .parent()
+            .ok_or("Could not get the parent of installed `protoc` path.")?
+            .to_path_buf()
+    };
 
     // Find the path where Dart executables are located.
     #[cfg(target_family = "windows")]
-    let pub_cache_bin_path = path::PathBuf::from(env::var("LOCALAPPDATA").unwrap())
+    let pub_cache_bin_path = path::PathBuf::from(env::var("LOCALAPPDATA")?)
         .join("Pub")
         .join("Cache")
         .join("bin");
     #[cfg(target_family = "unix")]
-    let pub_cache_bin_path = path::PathBuf::from(env::var("HOME").unwrap())
+    let pub_cache_bin_path = path::PathBuf::from(env::var("HOME")?)
         .join(".pub-cache")
         .join("bin");
 
@@ -44,19 +60,19 @@ fn main() {
     };
     path_var.push(protoc_path);
     path_var.push(pub_cache_bin_path);
-    env::set_var("PATH", env::join_paths(path_var).unwrap());
+    env::set_var("PATH", env::join_paths(path_var)?);
 
     // Get command-line arguments excluding the program name.
     let dart_command_args: Vec<String> = env::args().skip(1).collect();
 
-    // Build the command to run the Dart script.
-    let dart_path = which::which("dart").expect("Couldn't find Dart executable");
+    // Run the Dart script.
+    let dart_path = which::which("dart")?;
     let mut command = process::Command::new(dart_path);
     command.args(["run", "rinf"]);
     command.args(&dart_command_args);
+    command.status()?;
 
-    // Execute the command
-    let _ = command.status();
+    Ok(())
 }
 
 #[cfg(target_family = "wasm")]

--- a/rust_crate/src/main.rs
+++ b/rust_crate/src/main.rs
@@ -26,7 +26,7 @@ fn main() -> Result<()> {
             "OUT_DIR",
             out_path
                 .to_str()
-                .ok_or("Could not set environment variable path")?,
+                .ok_or("Could not set the path for `protoc` installation.")?,
         );
         let install_result = protoc_prebuilt::init("25.2");
         let (protoc_binary_path, _) = install_result.map_err(|_| {
@@ -76,6 +76,7 @@ fn main() -> Result<()> {
 }
 
 #[cfg(target_family = "wasm")]
-fn main() {
+fn main() -> Result<()> {
     // Dummy function to make the linter happy.
+    Ok(())
 }


### PR DESCRIPTION
## Changes

This PR removes all code that can panic(`unwrap`, `expect`) from the codebase.

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_ffi_plugin --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
