### PR TITLE
Upgrade `tokio_with_wasm` to 0.5.3

### DIFF
--- a/automate/__main__.py
+++ b/automate/__main__.py
@@ -60,13 +60,13 @@ elif sys.argv[1] == "prepare-test-app":
     )
     replace_text_in_file(
         "native/hub/Cargo.toml",
-        '# tokio_with_wasm = { version = "0.5.3", features = ["sync"] }',
-        'tokio_with_wasm = { version = "0.5.3", features = ["sync"] }',
+        "# tokio_with_wasm",
+        "tokio_with_wasm",
     )
     replace_text_in_file(
         "native/hub/Cargo.toml",
-        '# wasm-bindgen = "0.2.92"',
-        'wasm-bindgen = "0.2.92"',
+        "# wasm-bindgen",
+        "wasm-bindgen",
     )
 
     os.chdir("../")
@@ -114,13 +114,13 @@ elif sys.argv[1] == "prepare-user-app":
     )
     replace_text_in_file(
         "native/hub/Cargo.toml",
-        '# tokio_with_wasm = { version = "0.5.3", features = ["sync"] }',
-        'tokio_with_wasm = { version = "0.5.3", features = ["sync"] }',
+        "# tokio_with_wasm",
+        "tokio_with_wasm",
     )
     replace_text_in_file(
         "native/hub/Cargo.toml",
-        '# wasm-bindgen = "0.2.92"',
-        'wasm-bindgen = "0.2.92"',
+        "# wasm-bindgen",
+        "wasm-bindgen",
     )
 
     os.chdir("../")

--- a/automate/__main__.py
+++ b/automate/__main__.py
@@ -50,33 +50,23 @@ elif sys.argv[1] == "prepare-test-app":
     # Enable the web target, since it's not enabled by default.
     replace_text_in_file(
         "native/hub/src/lib.rs",
-        '// #[cfg(not(target_family = "wasm"))]',
-        '#[cfg(not(target_family = "wasm"))]',
+        "use tokio;",
+        "// use tokio;",
     )
     replace_text_in_file(
         "native/hub/src/lib.rs",
-        '// #[cfg(target_family = "wasm")]',
-        '#[cfg(target_family = "wasm")]',
-    )
-    replace_text_in_file(
-        "native/hub/src/lib.rs",
-        "// use tokio_with_wasm as tokio;",
-        "use tokio_with_wasm as tokio;",
+        "// use tokio_with_wasm::alias as tokio;",
+        "use tokio_with_wasm::alias as tokio;",
     )
     replace_text_in_file(
         "native/hub/Cargo.toml",
-        "# [target.'cfg(target_family = \"wasm\")'.dependencies]",
-        "[target.'cfg(target_family = \"wasm\")'.dependencies]",
+        '# tokio_with_wasm = { version = "0.5.3", features = ["sync"] }',
+        'tokio_with_wasm = { version = "0.5.3", features = ["sync"] }',
     )
     replace_text_in_file(
         "native/hub/Cargo.toml",
         '# wasm-bindgen = "0.2.92"',
         'wasm-bindgen = "0.2.92"',
-    )
-    replace_text_in_file(
-        "native/hub/Cargo.toml",
-        '# tokio_with_wasm = { version = "0.5.1", features = ["sync"] }',
-        'tokio_with_wasm = { version = "0.5.1", features = ["sync"] }',
     )
 
     os.chdir("../")
@@ -114,33 +104,23 @@ elif sys.argv[1] == "prepare-user-app":
     # Enable the web target, since it's not enabled by default.
     replace_text_in_file(
         "native/hub/src/lib.rs",
-        '// #[cfg(not(target_family = "wasm"))]',
-        '#[cfg(not(target_family = "wasm"))]',
+        "use tokio;",
+        "// use tokio;",
     )
     replace_text_in_file(
         "native/hub/src/lib.rs",
-        '// #[cfg(target_family = "wasm")]',
-        '#[cfg(target_family = "wasm")]',
-    )
-    replace_text_in_file(
-        "native/hub/src/lib.rs",
-        "// use tokio_with_wasm as tokio;",
-        "use tokio_with_wasm as tokio;",
+        "// use tokio_with_wasm::alias as tokio;",
+        "use tokio_with_wasm::alias as tokio;",
     )
     replace_text_in_file(
         "native/hub/Cargo.toml",
-        "# [target.'cfg(target_family = \"wasm\")'.dependencies]",
-        "[target.'cfg(target_family = \"wasm\")'.dependencies]",
+        '# tokio_with_wasm = { version = "0.5.3", features = ["sync"] }',
+        'tokio_with_wasm = { version = "0.5.3", features = ["sync"] }',
     )
     replace_text_in_file(
         "native/hub/Cargo.toml",
         '# wasm-bindgen = "0.2.92"',
         'wasm-bindgen = "0.2.92"',
-    )
-    replace_text_in_file(
-        "native/hub/Cargo.toml",
-        '# tokio_with_wasm = { version = "0.5.1", features = ["sync"] }',
-        'tokio_with_wasm = { version = "0.5.1", features = ["sync"] }',
     )
 
     os.chdir("../")

--- a/automate/__main__.py
+++ b/automate/__main__.py
@@ -50,23 +50,33 @@ elif sys.argv[1] == "prepare-test-app":
     # Enable the web target, since it's not enabled by default.
     replace_text_in_file(
         "native/hub/src/lib.rs",
-        "use tokio;",
-        "// use tokio;",
+        '// #[cfg(not(target_family = "wasm"))]',
+        '#[cfg(not(target_family = "wasm"))]',
     )
     replace_text_in_file(
         "native/hub/src/lib.rs",
-        "// use tokio_with_wasm",
-        "use tokio_with_wasm",
+        '// #[cfg(target_family = "wasm")]',
+        '#[cfg(target_family = "wasm")]',
+    )
+    replace_text_in_file(
+        "native/hub/src/lib.rs",
+        "// use tokio_with_wasm as tokio;",
+        "use tokio_with_wasm as tokio;",
     )
     replace_text_in_file(
         "native/hub/Cargo.toml",
-        "# wasm-bindgen",
-        "wasm-bindgen",
+        "# [target.'cfg(target_family = \"wasm\")'.dependencies]",
+        "[target.'cfg(target_family = \"wasm\")'.dependencies]",
     )
     replace_text_in_file(
         "native/hub/Cargo.toml",
-        "# tokio_with_wasm",
-        "tokio_with_wasm",
+        '# wasm-bindgen = "0.2.92"',
+        'wasm-bindgen = "0.2.92"',
+    )
+    replace_text_in_file(
+        "native/hub/Cargo.toml",
+        '# tokio_with_wasm = { version = "0.5.1", features = ["sync"] }',
+        'tokio_with_wasm = { version = "0.5.1", features = ["sync"] }',
     )
 
     os.chdir("../")
@@ -104,23 +114,33 @@ elif sys.argv[1] == "prepare-user-app":
     # Enable the web target, since it's not enabled by default.
     replace_text_in_file(
         "native/hub/src/lib.rs",
-        "use tokio;",
-        "// use tokio;",
+        '// #[cfg(not(target_family = "wasm"))]',
+        '#[cfg(not(target_family = "wasm"))]',
     )
     replace_text_in_file(
         "native/hub/src/lib.rs",
-        "// use tokio_with_wasm",
-        "use tokio_with_wasm",
+        '// #[cfg(target_family = "wasm")]',
+        '#[cfg(target_family = "wasm")]',
+    )
+    replace_text_in_file(
+        "native/hub/src/lib.rs",
+        "// use tokio_with_wasm as tokio;",
+        "use tokio_with_wasm as tokio;",
     )
     replace_text_in_file(
         "native/hub/Cargo.toml",
-        "# wasm-bindgen",
-        "wasm-bindgen",
+        "# [target.'cfg(target_family = \"wasm\")'.dependencies]",
+        "[target.'cfg(target_family = \"wasm\")'.dependencies]",
     )
     replace_text_in_file(
         "native/hub/Cargo.toml",
-        "# tokio_with_wasm",
-        "tokio_with_wasm",
+        '# wasm-bindgen = "0.2.92"',
+        'wasm-bindgen = "0.2.92"',
+    )
+    replace_text_in_file(
+        "native/hub/Cargo.toml",
+        '# tokio_with_wasm = { version = "0.5.1", features = ["sync"] }',
+        'tokio_with_wasm = { version = "0.5.1", features = ["sync"] }',
     )
 
     os.chdir("../")

--- a/documentation/docs/frequently-asked-questions.md
+++ b/documentation/docs/frequently-asked-questions.md
@@ -270,7 +270,7 @@ Here are the current constraints of the `wasm32-unknown-unknown` target:
 
 - Numerous functionalities within `std::fs` remain unimplemented.
 - Various features of `std::net` are not available. Consider using `reqwest` crate instead. `reqwest` supports `wasm32-unknown-unknown` and relies on JavaScript to perform network communications.
-- `std::thread::spawn` doesn't work. Consider using `tokio_with_wasm::tokio::task::spawn_blocking` instead.
+- `std::thread::spawn` doesn't work. Consider using `tokio_with_wasm::task::spawn_blocking` instead.
 - Several features of `std::time::Instant` are unimplemented. Consider using `chrono` as an alternative. `chrono` supports `wasm32-unknown-unknown` and relies on JavaScript to obtain system time.
 - In case of a panic in an asynchronous Rust task, it aborts and throws a JavaScript `RuntimeError` [which Rust cannot catch](https://stackoverflow.com/questions/59426545/rust-paniccatch-unwind-no-use-in-webassembly). A recommended practice is to replace `.unwrap` with `.expect` or handle errors with `Err` instances.
 

--- a/flutter_ffi_plugin/example/native/hub/Cargo.toml
+++ b/flutter_ffi_plugin/example/native/hub/Cargo.toml
@@ -14,7 +14,14 @@ crate-type = ["lib", "cdylib", "staticlib"]
 [dependencies]
 rinf = "6.12.1"
 prost = "0.12.6"
-# tokio = { version = "1", features = ["sync"] }
-wasm-bindgen = "0.2.92"                     # Uncomment this line to target the web
-tokio_with_wasm = "0.4.4"                   # Uncomment this line to target the web
+tokio = { version = "1", features = ["rt", "sync", "macros", "time"] }
 sample_crate = { path = "../sample_crate" }
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+wasm-bindgen = "0.2.92"
+tokio_with_wasm = { version = "0.5.0", features = [
+    "rt",
+    "sync",
+    "macros",
+    "time",
+] }

--- a/flutter_ffi_plugin/example/native/hub/Cargo.toml
+++ b/flutter_ffi_plugin/example/native/hub/Cargo.toml
@@ -19,7 +19,7 @@ sample_crate = { path = "../sample_crate" }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 wasm-bindgen = "0.2.92"
-tokio_with_wasm = { version = "0.5.0", features = [
+tokio_with_wasm = { version = "0.5.1", features = [
     "rt",
     "sync",
     "macros",

--- a/flutter_ffi_plugin/example/native/hub/Cargo.toml
+++ b/flutter_ffi_plugin/example/native/hub/Cargo.toml
@@ -15,13 +15,11 @@ crate-type = ["lib", "cdylib", "staticlib"]
 rinf = "6.12.1"
 prost = "0.12.6"
 tokio = { version = "1", features = ["rt", "sync", "macros", "time"] }
-sample_crate = { path = "../sample_crate" }
-
-[target.'cfg(target_family = "wasm")'.dependencies]
-wasm-bindgen = "0.2.92"
-tokio_with_wasm = { version = "0.5.1", features = [
+tokio_with_wasm = { version = "0.5.3", features = [
     "rt",
     "sync",
     "macros",
     "time",
 ] }
+wasm-bindgen = "0.2.92"
+sample_crate = { path = "../sample_crate" }

--- a/flutter_ffi_plugin/example/native/hub/src/lib.rs
+++ b/flutter_ffi_plugin/example/native/hub/src/lib.rs
@@ -4,10 +4,8 @@
 mod messages;
 mod sample_functions;
 
-#[cfg(not(target_family = "wasm"))]
-use tokio;
-#[cfg(target_family = "wasm")]
-use tokio_with_wasm as tokio;
+// use tokio;
+use tokio_with_wasm::alias as tokio;
 
 rinf::write_interface!();
 

--- a/flutter_ffi_plugin/example/native/hub/src/lib.rs
+++ b/flutter_ffi_plugin/example/native/hub/src/lib.rs
@@ -4,8 +4,10 @@
 mod messages;
 mod sample_functions;
 
-// use tokio;
-use tokio_with_wasm::tokio; // Uncomment this line to target the web
+#[cfg(not(target_family = "wasm"))]
+use tokio;
+#[cfg(target_family = "wasm")]
+use tokio_with_wasm as tokio;
 
 rinf::write_interface!();
 

--- a/flutter_ffi_plugin/example/native/hub/src/sample_functions.rs
+++ b/flutter_ffi_plugin/example/native/hub/src/sample_functions.rs
@@ -209,5 +209,13 @@ pub async fn run_debug_tests() {
     }
 
     debug_print!("Debug tests completed!");
-    panic!("INTENTIONAL DEBUG PANIC");
+
+    tokio::spawn(async {
+        // Panic in a separate task
+        // to avoid memory leak on the web.
+        // On the web (`wasm32-unknown-unknown`),
+        // catching and unwinding panics is not possible.
+        // It is better to avoid panicking code at all costs on the web.
+        panic!("INTENTIONAL DEBUG PANIC");
+    });
 }

--- a/flutter_ffi_plugin/template/native/hub/Cargo.toml
+++ b/flutter_ffi_plugin/template/native/hub/Cargo.toml
@@ -15,5 +15,8 @@ crate-type = ["lib", "cdylib", "staticlib"]
 rinf = "6.12.1"
 prost = "0.12.6"
 tokio = { version = "1", features = ["sync"] }
-# wasm-bindgen = "0.2.92" # Uncomment this line to target the web
-# tokio_with_wasm = "0.4.4" # Uncomment this line to target the web
+
+# Uncomment below to target the web.
+# [target.'cfg(target_family = "wasm")'.dependencies]
+# wasm-bindgen = "0.2.92"
+# tokio_with_wasm = { version = "0.5.0", features = ["sync"] }

--- a/flutter_ffi_plugin/template/native/hub/Cargo.toml
+++ b/flutter_ffi_plugin/template/native/hub/Cargo.toml
@@ -19,4 +19,4 @@ tokio = { version = "1", features = ["sync"] }
 # Uncomment below to target the web.
 # [target.'cfg(target_family = "wasm")'.dependencies]
 # wasm-bindgen = "0.2.92"
-# tokio_with_wasm = { version = "0.5.0", features = ["sync"] }
+# tokio_with_wasm = { version = "0.5.1", features = ["sync"] }

--- a/flutter_ffi_plugin/template/native/hub/Cargo.toml
+++ b/flutter_ffi_plugin/template/native/hub/Cargo.toml
@@ -17,6 +17,5 @@ prost = "0.12.6"
 tokio = { version = "1", features = ["sync"] }
 
 # Uncomment below to target the web.
-# [target.'cfg(target_family = "wasm")'.dependencies]
+# tokio_with_wasm = { version = "0.5.3", features = ["sync"] }
 # wasm-bindgen = "0.2.92"
-# tokio_with_wasm = { version = "0.5.1", features = ["sync"] }

--- a/flutter_ffi_plugin/template/native/hub/src/lib.rs
+++ b/flutter_ffi_plugin/template/native/hub/src/lib.rs
@@ -3,8 +3,11 @@
 
 mod messages;
 
+// Uncomment below to target the web.
+// #[cfg(not(target_family = "wasm"))]
 use tokio;
-// use tokio_with_wasm::tokio; // Uncomment this line to target the web
+// #[cfg(target_family = "wasm")]
+// use tokio_with_wasm as tokio;
 
 rinf::write_interface!();
 

--- a/flutter_ffi_plugin/template/native/hub/src/lib.rs
+++ b/flutter_ffi_plugin/template/native/hub/src/lib.rs
@@ -3,11 +3,8 @@
 
 mod messages;
 
-// Uncomment below to target the web.
-// #[cfg(not(target_family = "wasm"))]
-use tokio;
-// #[cfg(target_family = "wasm")]
-// use tokio_with_wasm as tokio;
+use tokio; // Comment this line to target the web.
+// use tokio_with_wasm::alias as tokio; // Uncomment this line to target the web.
 
 rinf::write_interface!();
 


### PR DESCRIPTION
## Changes

`tokio_with_wasm` 0.5.3 introduces cargo features, `abort` on `JoinHandle`, efficient `JoinHandle`, and panic-free behavior.

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_ffi_plugin --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
