### PR TITLE
Reduce memory copy on Dart signal

### DIFF
--- a/documentation/docs/tutorial.md
+++ b/documentation/docs/tutorial.md
@@ -127,13 +127,14 @@ Define an async Rust function that runs forever, sending numbers to Dart every s
 ```rust title="native/hub/src/sample_functions.rs"
 ...
 use crate::messages;
+use std::time::Duration;
 ...
 pub async fn stream_amazing_number() {
     use messages::tutorial_resource::*;
 
     let mut current_number: i32 = 1;
     loop {
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        tokio::time::sleep(Duration::from_secs(1)).await;
         MyAmazingNumber { current_number }.send_signal_to_dart(); // GENERATED
         current_number += 1;
     }

--- a/flutter_ffi_plugin/bin/src/message.dart
+++ b/flutter_ffi_plugin/bin/src/message.dart
@@ -418,20 +418,20 @@ use std::sync::OnceLock;
 use tokio::sync::mpsc::unbounded_channel;
 
 type SignalHandlers = OnceLock<
-    HashMap<i32, Box<dyn Fn(Vec<u8>, Vec<u8>)
+    HashMap<i32, Box<dyn Fn(&[u8], Vec<u8>)
         -> Result<(), Box<dyn Error>> + Send + Sync>>,
 >;
 static SIGNAL_HANDLERS: SignalHandlers = OnceLock::new();
 
 pub fn handle_dart_signal(
     message_id: i32,
-    message_bytes: Vec<u8>,
+    message_bytes: &[u8],
     binary: Vec<u8>
 ) {    
     let hash_map = SIGNAL_HANDLERS.get_or_init(|| {
         let mut new_hash_map = HashMap::<
             i32,
-            Box<dyn Fn(Vec<u8>, Vec<u8>)
+            Box<dyn Fn(&[u8], Vec<u8>)
                 -> Result<(), Box<dyn Error>> + Send + Sync>,
         >::new();
 ''';
@@ -452,10 +452,10 @@ pub fn handle_dart_signal(
           rustReceiveScript += '''
 new_hash_map.insert(
     ${markedMessage.id},
-    Box::new(|message_bytes: Vec<u8>, binary: Vec<u8>| {
+    Box::new(|message_bytes: &[u8], binary: Vec<u8>| {
         use super::$modulePath$filename::*;
         let message = ${normalizePascal(messageName)}::decode(
-            message_bytes.as_slice()
+            message_bytes
         )?;
         let dart_signal = DartSignal {
             message,

--- a/flutter_ffi_plugin/bin/src/message.dart
+++ b/flutter_ffi_plugin/bin/src/message.dart
@@ -418,7 +418,7 @@ use std::sync::OnceLock;
 use tokio::sync::mpsc::unbounded_channel;
 
 type SignalHandlers = OnceLock<
-    HashMap<i32, Box<dyn Fn(&[u8], Vec<u8>)
+    HashMap<i32, Box<dyn Fn(&[u8], &[u8])
         -> Result<(), Box<dyn Error>> + Send + Sync>>,
 >;
 static SIGNAL_HANDLERS: SignalHandlers = OnceLock::new();
@@ -426,12 +426,12 @@ static SIGNAL_HANDLERS: SignalHandlers = OnceLock::new();
 pub fn handle_dart_signal(
     message_id: i32,
     message_bytes: &[u8],
-    binary: Vec<u8>
+    binary: &[u8]
 ) {    
     let hash_map = SIGNAL_HANDLERS.get_or_init(|| {
         let mut new_hash_map = HashMap::<
             i32,
-            Box<dyn Fn(&[u8], Vec<u8>)
+            Box<dyn Fn(&[u8], &[u8])
                 -> Result<(), Box<dyn Error>> + Send + Sync>,
         >::new();
 ''';
@@ -452,14 +452,14 @@ pub fn handle_dart_signal(
           rustReceiveScript += '''
 new_hash_map.insert(
     ${markedMessage.id},
-    Box::new(|message_bytes: &[u8], binary: Vec<u8>| {
+    Box::new(|message_bytes: &[u8], binary: &[u8]| {
         use super::$modulePath$filename::*;
         let message = ${normalizePascal(messageName)}::decode(
             message_bytes
         )?;
         let dart_signal = DartSignal {
             message,
-            binary,
+            binary: binary.to_vec(),
         };
         let mut guard = ${snakeName.toUpperCase()}_CHANNEL.lock()?;
         if guard.is_none() {

--- a/flutter_ffi_plugin/example/native/hub/src/sample_functions.rs
+++ b/flutter_ffi_plugin/example/native/hub/src/sample_functions.rs
@@ -3,6 +3,7 @@
 use crate::messages;
 use crate::tokio;
 use rinf::debug_print;
+use std::time::Duration;
 use tokio::sync::Mutex;
 
 // Using the `cfg` macro enables conditional statement.
@@ -57,7 +58,7 @@ pub async fn stream_fractal() {
     tokio::spawn(async move {
         loop {
             // Wait for 40 milliseconds on each frame
-            tokio::time::sleep(std::time::Duration::from_millis(40)).await;
+            tokio::time::sleep(Duration::from_millis(40)).await;
             if sender.capacity() == 0 {
                 continue;
             }
@@ -120,7 +121,7 @@ pub async fn run_debug_tests() {
         return;
     }
 
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    tokio::time::sleep(Duration::from_secs(1)).await;
     debug_print!("Starting debug tests.");
 
     // Get the current time.
@@ -138,15 +139,15 @@ pub async fn run_debug_tests() {
 
     // Test `tokio::join!` for futures.
     let join_first = async {
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        tokio::time::sleep(Duration::from_secs(1)).await;
         debug_print!("First future finished.");
     };
     let join_second = async {
-        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        tokio::time::sleep(Duration::from_secs(2)).await;
         debug_print!("Second future finished.");
     };
     let join_third = async {
-        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        tokio::time::sleep(Duration::from_secs(3)).await;
         debug_print!("Third future finished.");
     };
     tokio::join!(join_first, join_second, join_third);

--- a/rust_crate/src/macros.rs
+++ b/rust_crate/src/macros.rs
@@ -42,7 +42,7 @@ macro_rules! write_interface {
         #[cfg(target_family = "wasm")]
         #[wasm_bindgen::prelude::wasm_bindgen]
         pub fn send_dart_signal_extern(message_id: i32, message_bytes: &[u8], binary: &[u8]) {
-            let message_bytes = message_bytes.to_vec();
+            let message_bytes = message_bytes;
             let binary = binary.to_vec();
             messages::generated::handle_dart_signal(message_id, message_bytes, binary);
         }

--- a/rust_crate/src/macros.rs
+++ b/rust_crate/src/macros.rs
@@ -33,7 +33,7 @@ macro_rules! write_interface {
             binary_size: usize,
         ) {
             let message_bytes =
-                unsafe { std::slice::from_raw_parts(message_pointer, message_size).to_vec() };
+                unsafe { std::slice::from_raw_parts(message_pointer, message_size) };
             let binary =
                 unsafe { std::slice::from_raw_parts(binary_pointer, binary_size).to_vec() };
             messages::generated::handle_dart_signal(message_id, message_bytes, binary);

--- a/rust_crate/src/macros.rs
+++ b/rust_crate/src/macros.rs
@@ -32,9 +32,9 @@ macro_rules! write_interface {
             binary_pointer: *const u8,
             binary_size: usize,
         ) {
-            let message_bytes =
-                unsafe { std::slice::from_raw_parts(message_pointer, message_size) };
-            let binary = unsafe { std::slice::from_raw_parts(binary_pointer, binary_size) };
+            use std::slice::from_raw_parts;
+            let message_bytes = unsafe { from_raw_parts(message_pointer, message_size) };
+            let binary = unsafe { from_raw_parts(binary_pointer, binary_size) };
             messages::generated::handle_dart_signal(message_id, message_bytes, binary);
         }
 

--- a/rust_crate/src/macros.rs
+++ b/rust_crate/src/macros.rs
@@ -34,8 +34,7 @@ macro_rules! write_interface {
         ) {
             let message_bytes =
                 unsafe { std::slice::from_raw_parts(message_pointer, message_size) };
-            let binary =
-                unsafe { std::slice::from_raw_parts(binary_pointer, binary_size).to_vec() };
+            let binary = unsafe { std::slice::from_raw_parts(binary_pointer, binary_size) };
             messages::generated::handle_dart_signal(message_id, message_bytes, binary);
         }
 

--- a/rust_crate/src/macros.rs
+++ b/rust_crate/src/macros.rs
@@ -42,7 +42,7 @@ macro_rules! write_interface {
         #[wasm_bindgen::prelude::wasm_bindgen]
         pub fn send_dart_signal_extern(message_id: i32, message_bytes: &[u8], binary: &[u8]) {
             let message_bytes = message_bytes;
-            let binary = binary.to_vec();
+            let binary = binary;
             messages::generated::handle_dart_signal(message_id, message_bytes, binary);
         }
     };


### PR DESCRIPTION
## Changes

This PR reduces memory copy on Dart signal

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_ffi_plugin --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
