### PR TITLE
Treat backtrace as an optional feature

### DIFF
--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -26,3 +26,4 @@ rinf = { version = "0.0.0", features = ["feature-name"] }
 ```
 
 - `multi-worker`: Starts a worker thread for each CPU core available on the system within the `tokio` runtime. By default, the `tokio` runtime uses only one thread. Enabling this feature allows the `tokio` runtime to utilize all the cores on your computer. This feature does not affect applications on the web platform.
+- `show-backtrace`: Prints the full backtrace in the CLI when a panic occurs in debug mode. This feature does not affect debugging on the web platform.

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -25,5 +25,5 @@ rinf config
 rinf = { version = "0.0.0", features = ["feature-name"] }
 ```
 
-- `multi-worker`: Starts a worker thread for each CPU core available on the system within the `tokio` runtime. By default, the `tokio` runtime uses only one thread. Enabling this feature allows the `tokio` runtime to utilize all the cores on your computer. This feature does not affect applications on the web platform.
+- `multi-worker`: Starts a worker thread for each CPU core available on the system within the `tokio` runtime by enabling its `rt-multi-thread` feature. By default, the `tokio` runtime uses only one thread. Enabling this feature allows the `tokio` runtime to utilize all the cores on your computer. This feature does not affect applications on the web platform.
 - `show-backtrace`: Prints the full backtrace in the CLI when a panic occurs in debug mode. In general, backtrace is not very helpful when debugging async apps, so consider using [`tracing`](https://crates.io/crates/tracing) for logging purposes. Note that this feature does not affect debugging on the web platform.

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -26,4 +26,4 @@ rinf = { version = "0.0.0", features = ["feature-name"] }
 ```
 
 - `multi-worker`: Starts a worker thread for each CPU core available on the system within the `tokio` runtime. By default, the `tokio` runtime uses only one thread. Enabling this feature allows the `tokio` runtime to utilize all the cores on your computer. This feature does not affect applications on the web platform.
-- `show-backtrace`: Prints the full backtrace in the CLI when a panic occurs in debug mode. This feature does not affect debugging on the web platform.
+- `show-backtrace`: Prints the full backtrace in the CLI when a panic occurs in debug mode. In general, backtrace is not very helpful when debugging async apps, so consider using [`tracing`](https://crates.io/crates/tracing) for logging purposes. Note that this feature does not affect debugging on the web platform.

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -21,6 +21,8 @@ rinf config
 
 ## 📦 Crate Features
 
+Customizing the behavior of the Rinf crate is possible through its crate features.
+
 ```toml title="native/hub/Cargo.toml"
 rinf = { version = "0.0.0", features = ["feature-name"] }
 ```

--- a/rust_crate/Cargo.toml
+++ b/rust_crate/Cargo.toml
@@ -10,10 +10,11 @@ rust-version = "1.70"
 
 [features]
 multi-worker = ["tokio/rt-multi-thread"]
+show-backtrace = ["backtrace"]
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 os-thread-local = "0.1.3"
-backtrace = "0.3.69"
+backtrace = { version = "0.3.69", optional = true }
 protoc-prebuilt = "0.3.0"
 home = "0.5.9"
 which = "6.0.0"

--- a/rust_crate/src/interface_os.rs
+++ b/rust_crate/src/interface_os.rs
@@ -41,10 +41,19 @@ where
     // Enable backtrace output for panics.
     #[cfg(debug_assertions)]
     {
-        std::panic::set_hook(Box::new(|panic_info| {
-            let backtrace = backtrace::Backtrace::new();
-            crate::debug_print!("A panic occurred in Rust.\n{panic_info}\n{backtrace:?}");
-        }));
+        #[cfg(not(feature = "backtrace"))]
+        {
+            std::panic::set_hook(Box::new(|panic_info| {
+                crate::debug_print!("A panic occurred in Rust.\n{panic_info}");
+            }));
+        }
+        #[cfg(feature = "backtrace")]
+        {
+            std::panic::set_hook(Box::new(|panic_info| {
+                let backtrace = backtrace::Backtrace::new();
+                crate::debug_print!("A panic occurred in Rust.\n{panic_info}\n{backtrace:?}");
+            }));
+        }
     }
 
     // Prepare the channel that will notify tokio runtime to shutdown


### PR DESCRIPTION
## Changes

Now backtrace isn't included by default, but can be enabled by a crate feature called `show-backtrace`

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_ffi_plugin --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
