### PR TITLE
Make the return type of the main empty

### DIFF
--- a/rust_crate/src/interface.rs
+++ b/rust_crate/src/interface.rs
@@ -28,7 +28,7 @@ pub struct DartSignal<T> {
 #[cfg(not(target_family = "wasm"))]
 pub fn start_rust_logic<F>(main_future: F) -> Result<()>
 where
-    F: Future + Send + 'static,
+    F: Future<Output = ()> + Send + 'static,
 {
     start_rust_logic_real(main_future)
 }
@@ -39,7 +39,7 @@ where
 #[cfg(target_family = "wasm")]
 pub fn start_rust_logic<F>(main_future: F) -> Result<()>
 where
-    F: Future + 'static,
+    F: Future<Output = ()> + 'static,
 {
     start_rust_logic_real(main_future)
 }

--- a/rust_crate/src/interface_os.rs
+++ b/rust_crate/src/interface_os.rs
@@ -36,7 +36,7 @@ static SHUTDOWN_SENDER: ShutdownSenderLock = OnceLock::new();
 
 pub fn start_rust_logic_real<F>(main_future: F) -> Result<()>
 where
-    F: Future + Send + 'static,
+    F: Future<Output = ()> + Send + 'static,
 {
     // Enable backtrace output for panics.
     #[cfg(debug_assertions)]
@@ -68,9 +68,7 @@ where
     {
         let tokio_runtime = Builder::new_current_thread().enable_all().build()?;
         thread::spawn(move || {
-            tokio_runtime.spawn(async {
-                main_future.await;
-            });
+            tokio_runtime.spawn(main_future);
             tokio_runtime.block_on(shutdown_receiver);
             // Dropping the tokio runtime makes it shut down.
             drop(tokio_runtime);

--- a/rust_crate/src/interface_web.rs
+++ b/rust_crate/src/interface_web.rs
@@ -6,7 +6,7 @@ use wasm_bindgen_futures::spawn_local;
 
 pub fn start_rust_logic_real<F>(main_future: F) -> Result<()>
 where
-    F: Future + 'static,
+    F: Future<Output = ()> + 'static,
 {
     // Add kind description for panics.
     #[cfg(debug_assertions)]
@@ -17,9 +17,7 @@ where
     }
 
     // Run the main function.
-    spawn_local(async {
-        main_future.await;
-    });
+    spawn_local(main_future);
 
     Ok(())
 }


### PR DESCRIPTION
## Changes

This matches the signature of Rust `main` to that of tokio.

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_ffi_plugin --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
