### PR TITLE
Make `get_dart_signal_receiver` return `Result`

### DIFF
--- a/documentation/docs/frequently-asked-questions.md
+++ b/documentation/docs/frequently-asked-questions.md
@@ -209,7 +209,7 @@ var currentInteractionId = 0;
 final myUniqueOutputs = Map<int, Completer<MyUniqueOutput>>();
 
 void main() async {
-    MyUniqueOutput.rustSignalStream.listen((rustSignal) {
+  MyUniqueOutput.rustSignalStream.listen((rustSignal) {
     final myUniqueInput = rustSignal.message;
     myUniqueOutputs[myUniqueInput.interactionId]!.complete(myUniqueInput);
   });

--- a/documentation/docs/frequently-asked-questions.md
+++ b/documentation/docs/frequently-asked-questions.md
@@ -233,10 +233,10 @@ onPressed: () async {
 ```
 
 ```rust title="native/hub/src/sample_functions.rs"
-pub async fn respond() {
+pub async fn respond() -> Result<()> {
     use messages::tutorial_resource::*;
 
-    let mut receiver = MyUniqueInput::get_dart_signal_receiver();
+    let mut receiver = MyUniqueInput::get_dart_signal_receiver()?;
     while let Some(dart_signal) = receiver.recv().await {
         let my_unique_input = dart_signal.message;
         MyUniqueOutput {
@@ -245,6 +245,8 @@ pub async fn respond() {
         }
         .send_signal_to_dart();
     }
+
+    Ok(())
 }
 ```
 

--- a/documentation/docs/frequently-asked-questions.md
+++ b/documentation/docs/frequently-asked-questions.md
@@ -131,9 +131,9 @@ There might be various Rust codes with these attribute above:
 
 ```rust title="Rust"
 #[cfg(target_family = "wasm")]
-...
+{}
 #[cfg(not(target_family = "wasm"))]
-...
+{}
 ```
 
 Since the environments of the web and native platforms are so different, there are times when you need to use these attributes to include and exclude parts of the code depending on whether they are targeting web or not.
@@ -147,6 +147,8 @@ By default, Rust-analyzer runs in native mode. To make it run in webassembly mod
 # You might have to restart Rust-analyzer for this change to take effect.
 target = "wasm32-unknown-unknown"
 ```
+
+You need to restart Rust language server for this to take effect.
 
 ### CMake cache is broken after I moved the app folder
 
@@ -171,12 +173,9 @@ If you are using older Android versions, you may encounter errors due to issues 
 To address this, you can modify `AndroidManifest.xml` files under `./android/app/src/` as follows.
 
 ```xml title="android/app/src/**/AndroidManifest.xml"
-...
 <application
     android:extractNativeLibs="true"
-    ...
 >
-...
 ```
 
 ### How can I await a response?
@@ -188,7 +187,7 @@ However, if you really need to store some state in a Flutter widget, you can ach
 ```proto title="messages/tutorial_resource.proto"
 syntax = "proto3";
 package tutorial_resource;
-...
+
 // [RINF:DART-SIGNAL]
 message MyUniqueInput {
   int32 interaction_id = 1;
@@ -203,7 +202,6 @@ message MyUniqueOutput {
 ```
 
 ```dart title="lib/main.dart"
-...
 import 'dart:async';
 import 'package:example_app/messages/tutorial_resource.pb.dart';
 
@@ -211,21 +209,17 @@ var currentInteractionId = 0;
 final myUniqueOutputs = Map<int, Completer<MyUniqueOutput>>();
 
 void main() async {
-  ...
-  MyUniqueOutput.rustSignalStream.listen((rustSignal) {
+    MyUniqueOutput.rustSignalStream.listen((rustSignal) {
     final myUniqueInput = rustSignal.message;
     myUniqueOutputs[myUniqueInput.interactionId]!.complete(myUniqueInput);
   });
-  ...
 }
-...
 ```
 
 ```dart title="lib/main.dart"
-...
 import 'dart:async';
 import 'package:example_app/messages/tutorial_resource.pb.dart';
-...
+
 onPressed: () async {
   final completer = Completer<MyUniqueOutput>();
   myUniqueOutputs[currentInteractionId] = completer;
@@ -236,7 +230,6 @@ onPressed: () async {
   currentInteractionId += 1;
   final myUniqueOutput = await completer.future;
 },
-...
 ```
 
 ```rust title="native/hub/src/sample_functions.rs"
@@ -257,7 +250,6 @@ pub async fn respond() {
 
 ```rust title="native/hub/src/lib.rs"
 async fn main() {
-    ...
     tokio::spawn(sample_functions::respond());
 }
 ```
@@ -324,9 +316,7 @@ import './messages/generated.dart';
 
 async void main() {
   await initializeRust(compiledLibPath: "/path/to/library/libhub.so");
-  ...
 }
-...
 ```
 
 This provided path will be used for finding dynamic library files on native platforms with Dart's `DynamicLibrary.open([compiledLibPath])`, and for loading the JavaScript module on the web with `import init, * as wasmBindings from "[compiledLibPath]"`.

--- a/documentation/docs/graceful-shutdown.md
+++ b/documentation/docs/graceful-shutdown.md
@@ -9,7 +9,7 @@ In some cases, you might need to run some finalization code in Rust before the a
 ```dart title="lib/main.dart"
 import 'dart:ui';
 import 'package:flutter/material.dart';
-...
+
 class MyApp extends StatefulWidget {
   const MyApp({super.key});
 
@@ -39,7 +39,6 @@ class _MyAppState extends State<MyApp> {
     );
   }
 }
-...
 ```
 
 It's worth noting that `AppLifecycleListener` or `dispose` cannot always be relied upon for app closings. Below is a text snippet quoted from the official [Flutter docs](https://api.flutter.dev/flutter/widgets/State/dispose.html):

--- a/documentation/docs/messaging.md
+++ b/documentation/docs/messaging.md
@@ -2,6 +2,59 @@
 
 There are 2 types of special comments that you can mark messages with.
 
+## 📢 Rust Signal
+
+`[RINF:RUST-SIGNAL]` generates a channel from Rust to Dart.
+
+```proto title="Protobuf"
+// [RINF:RUST-SIGNAL]
+message MyDataOutput { ... }
+```
+
+```dart title="Dart"
+StreamBuilder(
+  stream: MyDataOutput.rustSignalStream,
+  builder: (context, snapshot) {
+    final rustSignal = snapshot.data;
+    if (rustSignal == null) {
+      // Return an empty widget.
+    }
+    final myDataOutput = rustSignal.message;
+    // Return a filled widget.
+  },
+)
+```
+
+```rust title="Rust"
+MyDataOutput { ... }.send_signal_to_dart();
+```
+
+Use `[RINF:RUST-SIGNAL-BINARY]` to include binary data without the overhead of serialization.
+
+```proto title="Protobuf"
+// [RINF:RUST-SIGNAL-BINARY]
+message MyDataOutput { ... }
+```
+
+```dart title="Dart"
+StreamBuilder(
+  stream: MyDataOutput.rustSignalStream,
+  builder: (context, snapshot) {
+    final rustSignal = snapshot.data;
+    if (rustSignal == null) {
+      // Return an empty widget.
+    }
+    final myDataOutput = rustSignal.message;
+    // Return a filled widget.
+  },
+)
+```
+
+```rust title="Rust"
+let binary: Vec<u8> = vec![0; 64];
+MyDataOutput { ... }.send_signal_to_dart(binary);
+```
+
 ## 📭 Dart Signal
 
 `[RINF:DART-SIGNAL]` generates a channel from Dart to Rust.
@@ -42,46 +95,4 @@ while let Some(dart_signal) = receiver.recv().await {
     let binary: Vec<u8> = dart_signal.binary;
     // Custom Rust logic here
 }
-```
-
-## 📢 Rust Signal
-
-`[RINF:RUST-SIGNAL]` generates a channel from Rust to Dart.
-
-```proto title="Protobuf"
-// [RINF:RUST-SIGNAL]
-message MyDataOutput { ... }
-```
-
-```dart title="Dart"
-final stream = MyDataOutput.rustSignalStream;
-await for (final rustSignal in stream) {
-    MyDataOutput message = rustSignal.message;
-    // Custom Dart logic here
-}
-```
-
-```rust title="Rust"
-MyDataOutput { ... }.send_signal_to_dart();
-```
-
-Use `[RINF:RUST-SIGNAL-BINARY]` to include binary data without the overhead of serialization.
-
-```proto title="Protobuf"
-// [RINF:RUST-SIGNAL-BINARY]
-message MyDataOutput { ... }
-```
-
-```dart title="Dart"
-final stream = MyDataOutput.rustSignalStream;
-await for (final rustSignal in stream) {
-    MyDataOutput message = rustSignal.message;
-    Uint8List binary = rustSignal.binary;
-    // Custom Dart logic here
-}
-```
-
-```rust title="Rust"
-let binary: Vec<u8> = vec![0; 64];
-MyDataOutput { ... }.send_signal_to_dart(binary);
 ```

--- a/documentation/docs/messaging.md
+++ b/documentation/docs/messaging.md
@@ -19,7 +19,7 @@ StreamBuilder(
     if (rustSignal == null) {
       // Return an empty widget.
     }
-    final myDataOutput = rustSignal.message;
+    MyDataOutput message = rustSignal.message;
     // Return a filled widget.
   },
 )
@@ -44,7 +44,8 @@ StreamBuilder(
     if (rustSignal == null) {
       // Return an empty widget.
     }
-    final myDataOutput = rustSignal.message;
+    MyDataOutput message = rustSignal.message;
+    Uint8List binary = rustSignal.binary;
     // Return a filled widget.
   },
 )

--- a/documentation/docs/messaging.md
+++ b/documentation/docs/messaging.md
@@ -16,7 +16,7 @@ MyDataInput( ... ).sendSignalToRust();
 ```
 
 ```rust title="Rust"
-let mut receiver = MyDataInput::get_dart_signal_receiver();
+let mut receiver = MyDataInput::get_dart_signal_receiver()?;
 while let Some(dart_signal) = receiver.recv().await {
     let message: MyDataInput = dart_signal.message;
     // Custom Rust logic here
@@ -36,7 +36,7 @@ MyDataInput( ... ).sendSignalToRust(binary);
 ```
 
 ```rust title="Rust"
-let mut receiver = MyDataInput::get_dart_signal_receiver();
+let mut receiver = MyDataInput::get_dart_signal_receiver()?;
 while let Some(dart_signal) = receiver.recv().await {
     let message: MyDataInput = dart_signal.message;
     let binary: Vec<u8> = dart_signal.binary;

--- a/flutter_ffi_plugin/bin/src/message.dart
+++ b/flutter_ffi_plugin/bin/src/message.dart
@@ -294,10 +294,9 @@ impl ${normalizePascal(messageName)} {
     pub fn get_dart_signal_receiver()
         -> Result<UnboundedReceiver<DartSignal<Self>>> 
     {       
-        let mut guard =
-            ${snakeName.toUpperCase()}_CHANNEL.lock().map_err(|_| {
-                String::from("Could not acquire the channel lock.")
-            })?;
+        let mut guard = ${snakeName.toUpperCase()}_CHANNEL
+            .lock()
+            .map_err(|_| "Could not acquire the channel lock.")?;
         if guard.is_none() {
             let (sender, receiver) = unbounded_channel();
             guard.replace((sender, Some(receiver)));
@@ -321,7 +320,7 @@ impl ${normalizePascal(messageName)} {
         guard.replace((pair.0, None));
         let receiver = pair
             .1
-            .ok_or("Each Dart signal receiver can be taken only once")?;
+            .ok_or("Each Dart signal receiver can be taken only once.")?;
         Ok(receiver)
     }
 }

--- a/flutter_ffi_plugin/example/native/hub/src/common.rs
+++ b/flutter_ffi_plugin/example/native/hub/src/common.rs
@@ -1,0 +1,3 @@
+use std::error::Error;
+
+pub type Result<T> = std::result::Result<T, Box<dyn Error + Send + Sync>>;

--- a/flutter_ffi_plugin/example/native/hub/src/common.rs
+++ b/flutter_ffi_plugin/example/native/hub/src/common.rs
@@ -1,3 +1,7 @@
 use std::error::Error;
 
+/// Using this `Result` type alias allows
+/// handling any error type that implements the `Error` trait.
+/// This approach eliminates the need
+/// to depend on external crates for error handling.
 pub type Result<T> = std::result::Result<T, Box<dyn Error + Send + Sync>>;

--- a/flutter_ffi_plugin/example/native/hub/src/lib.rs
+++ b/flutter_ffi_plugin/example/native/hub/src/lib.rs
@@ -1,6 +1,7 @@
 //! This `hub` crate is the
 //! entry point of the Rust logic.
 
+mod common;
 mod messages;
 mod sample_functions;
 

--- a/flutter_ffi_plugin/example/native/hub/src/sample_functions.rs
+++ b/flutter_ffi_plugin/example/native/hub/src/sample_functions.rs
@@ -108,14 +108,15 @@ pub async fn stream_fractal() {
 
 // A dummy function that uses sample messages to eliminate warnings.
 #[allow(dead_code)]
-async fn use_messages() {
+async fn use_messages() -> Result<()> {
     use messages::sample_folder::enum_and_oneof::*;
-    _ = SampleInput::get_dart_signal_receiver();
+    let _ = SampleInput::get_dart_signal_receiver()?;
     SampleOutput {
         kind: 3,
         oneof_input: Some(sample_output::OneofInput::Age(25)),
     }
-    .send_signal_to_dart()
+    .send_signal_to_dart();
+    Ok(())
 }
 
 // Business logic for testing various crates.

--- a/flutter_ffi_plugin/example/native/hub/src/sample_functions.rs
+++ b/flutter_ffi_plugin/example/native/hub/src/sample_functions.rs
@@ -18,11 +18,11 @@ const IS_DEBUG_MODE: bool = false;
 static VECTOR: Mutex<Vec<bool>> = Mutex::const_new(Vec::new());
 
 // Business logic for the counter widget.
-pub async fn tell_numbers() {
+pub async fn tell_numbers() -> Result<()> {
     use messages::counter_number::*;
 
     // Stream getter is generated from a marked Protobuf message.
-    let mut receiver = SampleNumberInput::get_dart_signal_receiver();
+    let mut receiver = SampleNumberInput::get_dart_signal_receiver()?;
     while let Some(dart_signal) = receiver.recv().await {
         // Extract values from the message received from Dart.
         // This message is a type that's declared in its Protobuf file.
@@ -44,6 +44,8 @@ pub async fn tell_numbers() {
         }
         .send_signal_to_dart();
     }
+
+    Ok(())
 }
 
 // Business logic for the fractal image.

--- a/flutter_ffi_plugin/example/native/hub/src/sample_functions.rs
+++ b/flutter_ffi_plugin/example/native/hub/src/sample_functions.rs
@@ -1,5 +1,6 @@
 //! This crate is written for Rinf demonstrations.
 
+use crate::common::*;
 use crate::messages;
 use crate::tokio;
 use rinf::debug_print;
@@ -12,8 +13,8 @@ const IS_DEBUG_MODE: bool = true;
 #[cfg(not(debug_assertions))]
 const IS_DEBUG_MODE: bool = false;
 
-// This is one of the best ways to keep a global mutable state in Rust.
-// You can also use `tokio::sync::RwLock` or `tokio::sync::OnceCell`.
+// This is one of the ways to keep a global mutable state in Rust.
+// You can also use `tokio::sync::RwLock` or `std::lazy::LazyLock`.
 static VECTOR: Mutex<Vec<bool>> = Mutex::const_new(Vec::new());
 
 // Business logic for the counter widget.
@@ -116,9 +117,9 @@ async fn use_messages() {
 }
 
 // Business logic for testing various crates.
-pub async fn run_debug_tests() {
+pub async fn run_debug_tests() -> Result<()> {
     if !IS_DEBUG_MODE {
-        return;
+        return Ok(());
     }
 
     tokio::time::sleep(Duration::from_secs(1)).await;
@@ -130,11 +131,11 @@ pub async fn run_debug_tests() {
 
     // Fetch data from a web API.
     let url = "http://jsonplaceholder.typicode.com/todos/1";
-    let web_response = sample_crate::fetch_from_web_api(url).await;
+    let web_response = sample_crate::fetch_from_web_api(url).await?;
     debug_print!("Response from a web API: {web_response:?}");
 
     // Use a crate that accesses operating system APIs.
-    let hwid = sample_crate::get_hardward_id();
+    let hwid = sample_crate::get_hardward_id()?;
     debug_print!("Hardware ID: {hwid:?}");
 
     // Test `tokio::join!` for futures.
@@ -219,4 +220,6 @@ pub async fn run_debug_tests() {
         // It is better to avoid panicking code at all costs on the web.
         panic!("INTENTIONAL DEBUG PANIC");
     });
+
+    Ok(())
 }

--- a/flutter_ffi_plugin/example/native/sample_crate/src/common.rs
+++ b/flutter_ffi_plugin/example/native/sample_crate/src/common.rs
@@ -1,0 +1,3 @@
+use std::error::Error;
+
+pub type Result<T> = std::result::Result<T, Box<dyn Error + Send + Sync>>;

--- a/flutter_ffi_plugin/example/native/sample_crate/src/lib.rs
+++ b/flutter_ffi_plugin/example/native/sample_crate/src/lib.rs
@@ -18,8 +18,8 @@ pub fn get_hardward_id() -> Result<String> {
     Ok(hwid)
 }
 #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
-pub fn get_hardward_id() -> Option<String> {
-    None
+pub fn get_hardward_id() -> Result<String> {
+    Ok(String::from("UNSUPPORTED"))
 }
 
 // `chrono` supports all platforms, including web.

--- a/flutter_ffi_plugin/example/native/sample_crate/src/lib.rs
+++ b/flutter_ffi_plugin/example/native/sample_crate/src/lib.rs
@@ -1,17 +1,21 @@
 //! This crate is written for Rinf demonstrations.
 
+mod common;
 mod fractal;
+
+use common::*;
+
 pub use fractal::draw_fractal_image;
 
 // `machineid_rs` only supports desktop platforms.
 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
-pub fn get_hardward_id() -> Option<String> {
+pub fn get_hardward_id() -> Result<String> {
     let mut builder = machineid_rs::IdBuilder::new(machineid_rs::Encryption::MD5);
     builder
         .add_component(machineid_rs::HWIDComponent::SystemID)
         .add_component(machineid_rs::HWIDComponent::CPUCores);
-    let hwid = builder.build("mykey").ok()?;
-    Some(hwid)
+    let hwid = builder.build("mykey")?;
+    Ok(hwid)
 }
 #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
 pub fn get_hardward_id() -> Option<String> {
@@ -25,6 +29,7 @@ pub fn get_current_time() -> DateTime<offset::Local> {
 }
 
 // `reqwest` supports all platforms, including web.
-pub async fn fetch_from_web_api(url: &str) -> Option<String> {
-    reqwest::get(url).await.ok()?.text().await.ok()
+pub async fn fetch_from_web_api(url: &str) -> Result<String> {
+    let fetched = reqwest::get(url).await?.text().await?;
+    Ok(fetched)
 }

--- a/flutter_ffi_plugin/template/native/hub/Cargo.toml
+++ b/flutter_ffi_plugin/template/native/hub/Cargo.toml
@@ -14,8 +14,8 @@ crate-type = ["lib", "cdylib", "staticlib"]
 [dependencies]
 rinf = "6.12.1"
 prost = "0.12.6"
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", features = ["sync", "rt"] }
 
 # Uncomment below to target the web.
-# tokio_with_wasm = { version = "0.6.0", features = ["sync"] }
+# tokio_with_wasm = { version = "0.6.0", features = ["sync", "rt"] }
 # wasm-bindgen = "0.2.92"

--- a/flutter_ffi_plugin/template/native/hub/src/common.rs
+++ b/flutter_ffi_plugin/template/native/hub/src/common.rs
@@ -1,0 +1,3 @@
+use std::error::Error;
+
+pub type Result<T> = std::result::Result<T, Box<dyn Error + Send + Sync>>;

--- a/flutter_ffi_plugin/template/native/hub/src/common.rs
+++ b/flutter_ffi_plugin/template/native/hub/src/common.rs
@@ -1,3 +1,7 @@
 use std::error::Error;
 
+/// Using this `Result` type alias allows
+/// handling any error type that implements the `Error` trait.
+/// This approach eliminates the need
+/// to depend on external crates for error handling.
 pub type Result<T> = std::result::Result<T, Box<dyn Error + Send + Sync>>;

--- a/flutter_ffi_plugin/template/native/hub/src/lib.rs
+++ b/flutter_ffi_plugin/template/native/hub/src/lib.rs
@@ -4,8 +4,9 @@
 mod common;
 mod messages;
 
+use crate::common::*;
 use tokio; // Comment this line to target the web.
-           // use tokio_with_wasm::alias as tokio; // Uncomment this line to target the web.
+// use tokio_with_wasm::alias as tokio; // Uncomment this line to target the web.
 
 rinf::write_interface!();
 
@@ -15,11 +16,11 @@ rinf::write_interface!();
 // If you really need to use blocking code,
 // use `tokio::task::spawn_blocking`.
 async fn main() {
-    use messages::basic::*;
     tokio::spawn(communicate());
 }
 
 async fn communicate() -> Result<()> {
+    use messages::basic::*;
     // Send signals to Dart like below.
     SmallNumber { number: 7 }.send_signal_to_dart();
     // Get receivers that listen to Dart signals like below.
@@ -28,4 +29,5 @@ async fn communicate() -> Result<()> {
         let message: SmallText = dart_signal.message;
         rinf::debug_print!("{message:?}");
     }
+    Ok(())
 }

--- a/flutter_ffi_plugin/template/native/hub/src/lib.rs
+++ b/flutter_ffi_plugin/template/native/hub/src/lib.rs
@@ -1,10 +1,11 @@
 //! This `hub` crate is the
 //! entry point of the Rust logic.
 
+mod common;
 mod messages;
 
 use tokio; // Comment this line to target the web.
-// use tokio_with_wasm::alias as tokio; // Uncomment this line to target the web.
+           // use tokio_with_wasm::alias as tokio; // Uncomment this line to target the web.
 
 rinf::write_interface!();
 
@@ -15,10 +16,14 @@ rinf::write_interface!();
 // use `tokio::task::spawn_blocking`.
 async fn main() {
     use messages::basic::*;
+    tokio::spawn(communicate());
+}
+
+async fn communicate() -> Result<()> {
     // Send signals to Dart like below.
     SmallNumber { number: 7 }.send_signal_to_dart();
     // Get receivers that listen to Dart signals like below.
-    let mut receiver = SmallText::get_dart_signal_receiver();
+    let mut receiver = SmallText::get_dart_signal_receiver()?;
     while let Some(dart_signal) = receiver.recv().await {
         let message: SmallText = dart_signal.message;
         rinf::debug_print!("{message:?}");


### PR DESCRIPTION
## Changes

This PR completely removes `unwrap` and `expect` from the codebase. As a consequence, `get_dart_signal_receiver` returns `Result`.

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_ffi_plugin --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
