### PR TITLE
Return `RinfError` on errors

### DIFF
--- a/.github/workflows/quality_control.yaml
+++ b/.github/workflows/quality_control.yaml
@@ -54,6 +54,8 @@ jobs:
         working-directory: flutter_ffi_plugin/example/
         run: rinf message
 
+      # Targets are basically combinations of
+      # web/native and debug/release.
       - name: Check for errors in various targets
         run: |
           rustup target add wasm32-unknown-unknown
@@ -62,8 +64,10 @@ jobs:
           cargo clippy --target wasm32-unknown-unknown
           cargo clippy --target wasm32-unknown-unknown --release
 
+      # The `--all-features` flag doesn't work for the entire workspace.
+      # That's why we are checking only the library crate.
       - name: Check for errors with all features enabled
-        working-directory: flutter_ffi_plugin/example/native/hub
+        working-directory: rust_crate/
         run: cargo clippy --all-features
 
       - name: Analyze code

--- a/.github/workflows/quality_control.yaml
+++ b/.github/workflows/quality_control.yaml
@@ -54,13 +54,17 @@ jobs:
         working-directory: flutter_ffi_plugin/example/
         run: rinf message
 
-      - name: Check for any errors
+      - name: Check for errors in various targets
         run: |
           rustup target add wasm32-unknown-unknown
           cargo clippy
           cargo clippy --release
           cargo clippy --target wasm32-unknown-unknown
           cargo clippy --target wasm32-unknown-unknown --release
+
+      - name: Check for errors with all features enabled
+        working-directory: flutter_ffi_plugin/example/native/hub
+        run: cargo clippy --all-features
 
       - name: Analyze code
         run: |

--- a/flutter_ffi_plugin/bin/src/message.dart
+++ b/flutter_ffi_plugin/bin/src/message.dart
@@ -431,8 +431,7 @@ use tokio::sync::mpsc::unbounded_channel;
 
 type Handler = dyn Fn(&[u8], &[u8]) -> Result<(), RinfError> + Send + Sync;
 type SignalHandlers = HashMap<i32, Box<Handler>>;
-type SignalHandlersLock = OnceLock<SignalHandlers>;
-static SIGNAL_HANDLERS: SignalHandlersLock = OnceLock::new();
+static SIGNAL_HANDLERS: OnceLock<SignalHandlers> = OnceLock::new();
 
 pub fn handle_dart_signal(
     message_id: i32,

--- a/flutter_ffi_plugin/bin/src/message.dart
+++ b/flutter_ffi_plugin/bin/src/message.dart
@@ -258,16 +258,14 @@ import 'package:rinf/rinf.dart';
           rustPath,
           '''
 #![allow(unused_imports)]
-#![allow(dead_code)]
 
 use crate::tokio;
 use prost::Message;
-use rinf::{send_rust_signal, DartSignal};
+use rinf::{send_rust_signal, DartSignal, RinfError};
 use std::error::Error;
 use std::sync::Mutex;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
-type Result<T> = std::result::Result<T, Box<dyn Error + Send + Sync>>;
 ''',
           atFront: true,
         );
@@ -292,11 +290,11 @@ pub static ${snakeName.toUpperCase()}_CHANNEL: ${messageName}Cell =
 
 impl ${normalizePascal(messageName)} {
     pub fn get_dart_signal_receiver()
-        -> Result<UnboundedReceiver<DartSignal<Self>>> 
+        -> Result<UnboundedReceiver<DartSignal<Self>>, RinfError> 
     {       
         let mut guard = ${snakeName.toUpperCase()}_CHANNEL
             .lock()
-            .map_err(|_| "Could not acquire the channel lock.")?;
+            .map_err(|_| RinfError::MessageReceiverTaken)?;
         if guard.is_none() {
             let (sender, receiver) = unbounded_channel();
             guard.replace((sender, Some(receiver)));
@@ -308,7 +306,7 @@ impl ${normalizePascal(messageName)} {
             // which is now closed.
             let pair = guard
                 .as_ref()
-                .ok_or("Message channel in Rust not present.")?;
+                .ok_or(RinfError::NoMessageChannel)?;
             if pair.0.is_closed() {
                 let (sender, receiver) = unbounded_channel();
                 guard.replace((sender, Some(receiver)));
@@ -316,11 +314,11 @@ impl ${normalizePascal(messageName)} {
         }
         let pair = guard
             .take()
-            .ok_or("Message channel in Rust not present.")?;
+            .ok_or(RinfError::NoMessageChannel)?;
         guard.replace((pair.0, None));
         let receiver = pair
             .1
-            .ok_or("Each Dart signal receiver can be taken only once.")?;
+            .ok_or(RinfError::MessageReceiverTaken)?;
         Ok(receiver)
     }
 }
@@ -382,11 +380,16 @@ final ${camelName}Controller = StreamController<RustSignal<$messageName>>();
             '''
 impl ${normalizePascal(messageName)} {
     pub fn send_signal_to_dart(&self) {
-        send_rust_signal(
+        let result = send_rust_signal(
             ${markedMessage.id},
             self.encode_to_vec(),
             Vec::new(),
         );
+        if let Err(error) = result {
+            println!("Could not send Rust signal.");
+            println!("{error:?}");
+            println!("{self:?}");
+        }
     }
 }
 ''',
@@ -398,11 +401,16 @@ impl ${normalizePascal(messageName)} {
             '''
 impl ${normalizePascal(messageName)} {
     pub fn send_signal_to_dart(&self, binary: Vec<u8>) {
-        send_rust_signal(
+        let result = send_rust_signal(
             ${markedMessage.id},
             self.encode_to_vec(),
             binary,
-        );
+        );        
+        if let Err(error) = result {
+            println!("Could not send Rust signal.");
+            println!("{error:?}");
+            println!("{self:?}");
+        }
     }
 }
 ''',
@@ -421,17 +429,16 @@ impl ${normalizePascal(messageName)} {
 use crate::tokio;
 use prost::Message;
 use rinf::debug_print;
-use rinf::DartSignal;
+use rinf::{DartSignal, RinfError};
 use std::collections::HashMap;
 use std::error::Error;
 use std::sync::OnceLock;
 use tokio::sync::mpsc::unbounded_channel;
 
-type SignalHandlers = OnceLock<
-    HashMap<i32, Box<dyn Fn(&[u8], &[u8])
-        -> Result<(), Box<dyn Error>> + Send + Sync>>,
->;
-static SIGNAL_HANDLERS: SignalHandlers = OnceLock::new();
+type Handler = dyn Fn(&[u8], &[u8]) -> Result<(), RinfError> + Send + Sync;
+type SignalHandlers = HashMap<i32, Box<Handler>>;
+type SignalHandlersLock = OnceLock<SignalHandlers>;
+static SIGNAL_HANDLERS: SignalHandlersLock = OnceLock::new();
 
 pub fn handle_dart_signal(
     message_id: i32,
@@ -439,11 +446,7 @@ pub fn handle_dart_signal(
     binary: &[u8]
 ) {    
     let hash_map = SIGNAL_HANDLERS.get_or_init(|| {
-        let mut new_hash_map = HashMap::<
-            i32,
-            Box<dyn Fn(&[u8], &[u8])
-                -> Result<(), Box<dyn Error>> + Send + Sync>,
-        >::new();
+        let mut new_hash_map: SignalHandlers = HashMap::new();
 ''';
   for (final entry in markedMessagesAll.entries) {
     final subpath = entry.key;
@@ -464,14 +467,16 @@ new_hash_map.insert(
     ${markedMessage.id},
     Box::new(|message_bytes: &[u8], binary: &[u8]| {
         use super::$modulePath$filename::*;
-        let message = ${normalizePascal(messageName)}::decode(
-            message_bytes
-        )?;
+        let message =
+            ${normalizePascal(messageName)}::decode(message_bytes)
+            .map_err(|_| RinfError::DecodeMessage)?;
         let dart_signal = DartSignal {
             message,
             binary: binary.to_vec(),
         };
-        let mut guard = ${snakeName.toUpperCase()}_CHANNEL.lock()?;
+        let mut guard = ${snakeName.toUpperCase()}_CHANNEL
+            .lock()
+            .map_err(|_| RinfError::LockMessageChannel)?;
         if guard.is_none() {
             let (sender, receiver) = unbounded_channel();
             guard.replace((sender, Some(receiver)));
@@ -483,7 +488,7 @@ new_hash_map.insert(
             // which is now closed.
             let pair = guard
                 .as_ref()
-                .ok_or("Message channel in Rust not present.")?;
+                .ok_or(RinfError::NoMessageChannel)?;
             if pair.0.is_closed() {
                 let (sender, receiver) = unbounded_channel();
                 guard.replace((sender, Some(receiver)));
@@ -491,7 +496,7 @@ new_hash_map.insert(
         }
         let pair = guard
             .as_ref()
-            .ok_or("Message channel in Rust not present.")?;
+            .ok_or(RinfError::NoMessageChannel)?;
         let sender = &pair.0;
         let _ = sender.send(dart_signal);
         Ok(())

--- a/flutter_ffi_plugin/bin/src/message.dart
+++ b/flutter_ffi_plugin/bin/src/message.dart
@@ -293,7 +293,7 @@ impl ${normalizePascal(messageName)} {
     {       
         let mut guard = ${snakeName.toUpperCase()}_CHANNEL
             .lock()
-            .map_err(|_| RinfError::MessageReceiverTaken)?;
+            .map_err(|_| RinfError::LockMessageChannel)?;
         if guard.is_none() {
             let (sender, receiver) = unbounded_channel();
             guard.replace((sender, Some(receiver)));

--- a/flutter_ffi_plugin/bin/src/message.dart
+++ b/flutter_ffi_plugin/bin/src/message.dart
@@ -262,7 +262,6 @@ import 'package:rinf/rinf.dart';
 use crate::tokio;
 use prost::Message;
 use rinf::{debug_print, send_rust_signal, DartSignal, RinfError};
-use std::error::Error;
 use std::sync::Mutex;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 

--- a/flutter_ffi_plugin/bin/src/message.dart
+++ b/flutter_ffi_plugin/bin/src/message.dart
@@ -423,8 +423,7 @@ impl ${normalizePascal(messageName)} {
 
 use crate::tokio;
 use prost::Message;
-use rinf::debug_print;
-use rinf::{DartSignal, RinfError};
+use rinf::{debug_print, DartSignal, RinfError};
 use std::collections::HashMap;
 use std::error::Error;
 use std::sync::OnceLock;

--- a/flutter_ffi_plugin/bin/src/message.dart
+++ b/flutter_ffi_plugin/bin/src/message.dart
@@ -385,7 +385,7 @@ impl ${normalizePascal(messageName)} {
             Vec::new(),
         );
         if let Err(error) = result {
-            debug_print!("{error}\n{self:?}");
+            debug_print!("{error}\\n{self:?}");
         }
     }
 }
@@ -404,7 +404,7 @@ impl ${normalizePascal(messageName)} {
             binary,
         );
         if let Err(error) = result {
-            debug_print!("{error}\n{self:?}");
+            debug_print!("{error}\\n{self:?}");
         }
     }
 }

--- a/flutter_ffi_plugin/example/native/hub/src/sample_functions.rs
+++ b/flutter_ffi_plugin/example/native/hub/src/sample_functions.rs
@@ -91,7 +91,7 @@ pub async fn stream_fractal() {
                 Ok(inner) => inner,
                 Err(_) => continue,
             };
-            if let Some(fractal_image) = received_frame {
+            if let Ok(fractal_image) = received_frame {
                 // Stream the image data to Dart.
                 SampleFractal {
                     current_scale,

--- a/flutter_ffi_plugin/example/native/sample_crate/src/common.rs
+++ b/flutter_ffi_plugin/example/native/sample_crate/src/common.rs
@@ -1,3 +1,0 @@
-use std::error::Error;
-
-pub type Result<T> = std::result::Result<T, Box<dyn Error + Send + Sync>>;

--- a/flutter_ffi_plugin/example/native/sample_crate/src/error.rs
+++ b/flutter_ffi_plugin/example/native/sample_crate/src/error.rs
@@ -1,0 +1,18 @@
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+pub struct ExampleError(pub Box<dyn Error + Send + Sync>);
+
+impl fmt::Display for ExampleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let source = self.0.as_ref();
+        write!(f, "An error occured inside the example code.\n{source}")
+    }
+}
+
+impl Error for ExampleError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(self.0.as_ref())
+    }
+}

--- a/flutter_ffi_plugin/example/native/sample_crate/src/fractal.rs
+++ b/flutter_ffi_plugin/example/native/sample_crate/src/fractal.rs
@@ -2,6 +2,7 @@
 //! Copied and modified from
 //! https://github.com/abour/fractal repository.
 
+use crate::error::ExampleError;
 use image::ImageEncoder;
 
 const WIDTH: u32 = 384;
@@ -10,7 +11,7 @@ const BUF_SIZE: u32 = WIDTH * HEIGHT * 3;
 const SIZE: f64 = 0.000000001;
 const MAX_ITER: u32 = 1000;
 
-pub fn draw_fractal_image(scale: f64) -> Option<Vec<u8>> {
+pub fn draw_fractal_image(scale: f64) -> Result<Vec<u8>, ExampleError> {
     let point_x: f64 = -0.5557506;
     let point_y: f64 = -0.55560;
     let mut buffer: Vec<u8> = vec![0; BUF_SIZE as usize];
@@ -27,8 +28,8 @@ pub fn draw_fractal_image(scale: f64) -> Option<Vec<u8>> {
     );
 
     match result {
-        Ok(_) => Some(image_data),
-        Err(_) => None,
+        Ok(_) => Ok(image_data),
+        Err(error) => Err(ExampleError(error.into())),
     }
 }
 

--- a/flutter_ffi_plugin/example/native/sample_crate/src/lib.rs
+++ b/flutter_ffi_plugin/example/native/sample_crate/src/lib.rs
@@ -20,7 +20,7 @@ pub fn get_hardward_id() -> Result<String, ExampleError> {
     Ok(hwid)
 }
 #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
-pub fn get_hardward_id() -> Result<String> {
+pub fn get_hardward_id() -> Result<String, ExampleError> {
     Ok(String::from("UNSUPPORTED"))
 }
 

--- a/flutter_ffi_plugin/example/native/sample_crate/src/lib.rs
+++ b/flutter_ffi_plugin/example/native/sample_crate/src/lib.rs
@@ -1,20 +1,22 @@
 //! This crate is written for Rinf demonstrations.
 
-mod common;
+mod error;
 mod fractal;
 
-use common::*;
+use error::ExampleError;
 
 pub use fractal::draw_fractal_image;
 
 // `machineid_rs` only supports desktop platforms.
 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
-pub fn get_hardward_id() -> Result<String> {
+pub fn get_hardward_id() -> Result<String, ExampleError> {
     let mut builder = machineid_rs::IdBuilder::new(machineid_rs::Encryption::MD5);
     builder
         .add_component(machineid_rs::HWIDComponent::SystemID)
         .add_component(machineid_rs::HWIDComponent::CPUCores);
-    let hwid = builder.build("mykey")?;
+    let hwid = builder
+        .build("mykey")
+        .map_err(|error| ExampleError(error.into()))?;
     Ok(hwid)
 }
 #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
@@ -29,7 +31,12 @@ pub fn get_current_time() -> DateTime<offset::Local> {
 }
 
 // `reqwest` supports all platforms, including web.
-pub async fn fetch_from_web_api(url: &str) -> Result<String> {
-    let fetched = reqwest::get(url).await?.text().await?;
+pub async fn fetch_from_web_api(url: &str) -> Result<String, ExampleError> {
+    let fetched = reqwest::get(url)
+        .await
+        .map_err(|error| ExampleError(error.into()))?
+        .text()
+        .await
+        .map_err(|error| ExampleError(error.into()))?;
     Ok(fetched)
 }

--- a/rust_crate/src/common.rs
+++ b/rust_crate/src/common.rs
@@ -1,3 +1,0 @@
-use std::error::Error;
-
-pub type Result<T> = std::result::Result<T, Box<dyn Error>>;

--- a/rust_crate/src/error.rs
+++ b/rust_crate/src/error.rs
@@ -1,0 +1,43 @@
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+pub enum RinfError {
+    LockDartIsolate,
+    NoDartIsolate,
+    BuildRuntime,
+    LockMessageChannel,
+    NoMessageChannel,
+    MessageReceiverTaken,
+    DecodeMessage,
+}
+
+impl fmt::Display for RinfError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RinfError::LockDartIsolate => {
+                write!(f, "Could not acquire the Dart isolate lock.")
+            }
+            RinfError::NoDartIsolate => {
+                write!(f, "Dart isolate for Rust signals was not created.")
+            }
+            RinfError::BuildRuntime => {
+                write!(f, "Could not build the tokio runtime.")
+            }
+            RinfError::LockMessageChannel => {
+                write!(f, "Could not acquire the message channel lock.")
+            }
+            RinfError::NoMessageChannel => {
+                write!(f, "Message channel was not created.",)
+            }
+            RinfError::MessageReceiverTaken => {
+                write!(f, "Each Dart signal receiver can be taken only once.")
+            }
+            RinfError::DecodeMessage => {
+                write!(f, "Could not decode the message.")
+            }
+        }
+    }
+}
+
+impl Error for RinfError {}

--- a/rust_crate/src/error.rs
+++ b/rust_crate/src/error.rs
@@ -10,6 +10,7 @@ pub enum RinfError {
     NoMessageChannel,
     MessageReceiverTaken,
     DecodeMessage,
+    NoSignalHandler,
 }
 
 impl fmt::Display for RinfError {
@@ -35,6 +36,9 @@ impl fmt::Display for RinfError {
             }
             RinfError::DecodeMessage => {
                 write!(f, "Could not decode the message.")
+            }
+            RinfError::NoSignalHandler => {
+                write!(f, "Could not find the handler for Dart signal.")
             }
         }
     }

--- a/rust_crate/src/interface.rs
+++ b/rust_crate/src/interface.rs
@@ -1,4 +1,4 @@
-use crate::common::*;
+use crate::error::RinfError;
 use std::future::Future;
 
 #[cfg(not(target_family = "wasm"))]
@@ -26,7 +26,7 @@ pub struct DartSignal<T> {
 /// the `Runtime` object itself might be moved between threads,
 /// along with all the tasks it manages.
 #[cfg(not(target_family = "wasm"))]
-pub fn start_rust_logic<F>(main_future: F) -> Result<()>
+pub fn start_rust_logic<F>(main_future: F) -> Result<(), RinfError>
 where
     F: Future<Output = ()> + Send + 'static,
 {
@@ -37,7 +37,7 @@ where
 /// On the web, futures usually don't implement the `Send` trait
 /// because JavaScript environment is fundamentally single-threaded.
 #[cfg(target_family = "wasm")]
-pub fn start_rust_logic<F>(main_future: F) -> Result<()>
+pub fn start_rust_logic<F>(main_future: F) -> Result<(), RinfError>
 where
     F: Future<Output = ()> + 'static,
 {
@@ -45,11 +45,10 @@ where
 }
 
 /// Send a signal to Dart.
-pub fn send_rust_signal(message_id: i32, message_bytes: Vec<u8>, binary: Vec<u8>) {
-    let result = send_rust_signal_real(message_id, message_bytes, binary);
-    if let Err(error) = result {
-        // We cannot use `debug_print` here because
-        // it uses `send_rust_siganl` internally.
-        println!("Could not send Rust signal.\n{error:#?}");
-    }
+pub fn send_rust_signal(
+    message_id: i32,
+    message_bytes: Vec<u8>,
+    binary: Vec<u8>,
+) -> Result<(), RinfError> {
+    send_rust_signal_real(message_id, message_bytes, binary)
 }

--- a/rust_crate/src/interface_os.rs
+++ b/rust_crate/src/interface_os.rs
@@ -67,7 +67,10 @@ where
     // Build the tokio runtime.
     #[cfg(not(feature = "multi-worker"))]
     {
-        let tokio_runtime = Builder::new_current_thread().enable_all().build()?;
+        let tokio_runtime = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|_| RinfError::BuildRuntime)?;
         thread::spawn(move || {
             tokio_runtime.spawn(main_future);
             tokio_runtime.block_on(shutdown_receiver);
@@ -78,10 +81,7 @@ where
     #[cfg(feature = "multi-worker")]
     {
         static TOKIO_RUNTIME: Mutex<Option<tokio::runtime::Runtime>> = Mutex::new(None);
-        let tokio_runtime = Builder::new_multi_thread()
-            .enable_all()
-            .build()
-            .map_err(|_| RinfError::BuildRuntime)?;
+        let tokio_runtime = Builder::new_multi_thread().enable_all().build()?;
         tokio_runtime.spawn(async {
             main_future.await;
         });

--- a/rust_crate/src/interface_os.rs
+++ b/rust_crate/src/interface_os.rs
@@ -18,7 +18,8 @@ pub extern "C" fn prepare_isolate_extern(port: i64) {
     let mut guard = match DART_ISOLATE.lock() {
         Ok(inner) => inner,
         Err(_) => {
-            println!("Could not unlock Dart isolate mutex.");
+            let error = RinfError::LockDartIsolate;
+            println!("{error}");
             return;
         }
     };

--- a/rust_crate/src/interface_os.rs
+++ b/rust_crate/src/interface_os.rs
@@ -81,7 +81,10 @@ where
     #[cfg(feature = "multi-worker")]
     {
         static TOKIO_RUNTIME: Mutex<Option<tokio::runtime::Runtime>> = Mutex::new(None);
-        let tokio_runtime = Builder::new_multi_thread().enable_all().build()?;
+        let tokio_runtime = Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .map_err(|_| RinfError::BuildRuntime)?;
         tokio_runtime.spawn(async {
             main_future.await;
         });

--- a/rust_crate/src/interface_os.rs
+++ b/rust_crate/src/interface_os.rs
@@ -67,10 +67,7 @@ where
     // Build the tokio runtime.
     #[cfg(not(feature = "multi-worker"))]
     {
-        let tokio_runtime = Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(|_| RinfError::BuildRuntime)?;
+        let tokio_runtime = Builder::new_current_thread().enable_all().build()?;
         thread::spawn(move || {
             tokio_runtime.spawn(main_future);
             tokio_runtime.block_on(shutdown_receiver);

--- a/rust_crate/src/interface_os.rs
+++ b/rust_crate/src/interface_os.rs
@@ -120,15 +120,12 @@ pub fn send_rust_signal_real(
     message_bytes: Vec<u8>,
     binary: Vec<u8>,
 ) -> Result<(), RinfError> {
-    // When `DART_ISOLATE` is not initialized, do nothing.
+    // When `DART_ISOLATE` is not initialized, just return the error.
     // This can happen when running test code in Rust.
     let guard = DART_ISOLATE
         .lock()
         .map_err(|_| RinfError::LockDartIsolate)?;
-    let dart_isolate = guard
-        .as_ref()
-        .ok_or("Dart isolate for sending Rust signals is not present.")
-        .map_err(|_| RinfError::NoDartIsolate)?;
+    let dart_isolate = guard.as_ref().ok_or(RinfError::NoDartIsolate)?;
 
     // If a `Vec<u8>` is empty, we can't just simply send it to Dart
     // because panic can occur from null pointers.

--- a/rust_crate/src/interface_web.rs
+++ b/rust_crate/src/interface_web.rs
@@ -1,10 +1,10 @@
-use crate::common::*;
+use crate::error::RinfError;
 use js_sys::Uint8Array;
 use std::future::Future;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::spawn_local;
 
-pub fn start_rust_logic_real<F>(main_future: F) -> Result<()>
+pub fn start_rust_logic_real<F>(main_future: F) -> Result<(), RinfError>
 where
     F: Future<Output = ()> + 'static,
 {
@@ -32,12 +32,11 @@ pub fn send_rust_signal_real(
     message_id: i32,
     message_bytes: Vec<u8>,
     binary: Vec<u8>,
-) -> Result<()> {
+) -> Result<(), RinfError> {
     send_rust_signal_extern(
         message_id,
         js_sys::Uint8Array::from(message_bytes.as_slice()),
         js_sys::Uint8Array::from(binary.as_slice()),
     );
-
     Ok(())
 }

--- a/rust_crate/src/lib.rs
+++ b/rust_crate/src/lib.rs
@@ -1,4 +1,4 @@
-mod common;
+mod error;
 mod macros;
 
 mod interface;
@@ -7,4 +7,5 @@ mod interface_os;
 #[cfg(target_family = "wasm")]
 mod interface_web;
 
+pub use error::*;
 pub use interface::*;

--- a/rust_crate/src/macros.rs
+++ b/rust_crate/src/macros.rs
@@ -10,7 +10,8 @@ macro_rules! write_interface {
         pub extern "C" fn start_rust_logic_extern() {
             let result = $crate::start_rust_logic(main());
             if let Err(error) = result {
-                println!("Could not start Rust logic.\n{error:#?}");
+                println!("Could not start Rust logic.");
+                println!("{error:?}");
             }
         }
 
@@ -19,7 +20,8 @@ macro_rules! write_interface {
         pub fn start_rust_logic_extern() {
             let result = $crate::start_rust_logic(main());
             if let Err(error) = result {
-                println!("Could not start Rust logic.\n{error:#?}");
+                println!("Could not start Rust logic.");
+                println!("{error:?}");
             }
         }
 
@@ -59,11 +61,14 @@ macro_rules! debug_print {
     ( $( $t:tt )* ) => {
         let rust_report = format!( $( $t )* );
         #[cfg(debug_assertions)]
-        $crate::send_rust_signal(
+        let result = $crate::send_rust_signal(
             -1, // This is a special message ID for Rust reports
             Vec::new(),
-            rust_report.into_bytes(),
+            rust_report.clone().into_bytes(),
         );
+        if let Err(error) = result {
+            println!("Could not send Rust report.\n{error:?}\n{rust_report}");
+        }
         #[cfg(not(debug_assertions))]
         let _ = rust_report;
     }

--- a/rust_crate/src/macros.rs
+++ b/rust_crate/src/macros.rs
@@ -10,8 +10,7 @@ macro_rules! write_interface {
         pub extern "C" fn start_rust_logic_extern() {
             let result = $crate::start_rust_logic(main());
             if let Err(error) = result {
-                println!("Could not start Rust logic.");
-                println!("{error:?}");
+                rinf::debug_print!("{error}");
             }
         }
 
@@ -20,8 +19,7 @@ macro_rules! write_interface {
         pub fn start_rust_logic_extern() {
             let result = $crate::start_rust_logic(main());
             if let Err(error) = result {
-                println!("Could not start Rust logic.");
-                println!("{error:?}");
+                rinf::debug_print!("{error}");
             }
         }
 
@@ -37,7 +35,10 @@ macro_rules! write_interface {
             use std::slice::from_raw_parts;
             let message_bytes = unsafe { from_raw_parts(message_pointer, message_size) };
             let binary = unsafe { from_raw_parts(binary_pointer, binary_size) };
-            messages::generated::handle_dart_signal(message_id, message_bytes, binary);
+            let result = messages::generated::handle_dart_signal(message_id, message_bytes, binary);
+            if let Err(error) = result {
+                rinf::debug_print!("{error}");
+            }
         }
 
         #[cfg(target_family = "wasm")]
@@ -45,7 +46,10 @@ macro_rules! write_interface {
         pub fn send_dart_signal_extern(message_id: i32, message_bytes: &[u8], binary: &[u8]) {
             let message_bytes = message_bytes;
             let binary = binary;
-            messages::generated::handle_dart_signal(message_id, message_bytes, binary);
+            let result = messages::generated::handle_dart_signal(message_id, message_bytes, binary);
+            if let Err(error) = result {
+                rinf::debug_print!("{error}");
+            }
         }
     };
 }
@@ -67,7 +71,7 @@ macro_rules! debug_print {
             rust_report.clone().into_bytes(),
         );
         if let Err(error) = result {
-            println!("Could not send Rust report.\n{error:?}\n{rust_report}");
+            println!("{error}\n{rust_report}");
         }
         #[cfg(not(debug_assertions))]
         let _ = rust_report;

--- a/rust_crate/src/macros.rs
+++ b/rust_crate/src/macros.rs
@@ -65,13 +65,15 @@ macro_rules! debug_print {
     ( $( $t:tt )* ) => {
         let rust_report = format!( $( $t )* );
         #[cfg(debug_assertions)]
-        let result = $crate::send_rust_signal(
-            -1, // This is a special message ID for Rust reports
-            Vec::new(),
-            rust_report.clone().into_bytes(),
-        );
-        if let Err(error) = result {
-            println!("{error}\n{rust_report}");
+        {
+            let result = $crate::send_rust_signal(
+                -1, // This is a special message ID for Rust reports
+                Vec::new(),
+                rust_report.clone().into_bytes(),
+            );
+            if let Err(error) = result {
+                println!("{error}\n{rust_report}");
+            }
         }
         #[cfg(not(debug_assertions))]
         let _ = rust_report;

--- a/rust_crate/src/main.rs
+++ b/rust_crate/src/main.rs
@@ -1,7 +1,5 @@
-use std::error::Error;
-
 #[cfg(not(target_family = "wasm"))]
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     use std::env;
     use std::fs;
     use std::path;
@@ -75,7 +73,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 }
 
 #[cfg(target_family = "wasm")]
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Dummy function to make the linter happy.
     Ok(())
 }

--- a/rust_crate/src/main.rs
+++ b/rust_crate/src/main.rs
@@ -1,8 +1,7 @@
-mod common;
-use common::*;
+use std::error::Error;
 
 #[cfg(not(target_family = "wasm"))]
-fn main() -> Result<()> {
+fn main() -> Result<(), Box<dyn Error>> {
     use std::env;
     use std::fs;
     use std::path;
@@ -76,7 +75,7 @@ fn main() -> Result<()> {
 }
 
 #[cfg(target_family = "wasm")]
-fn main() -> Result<()> {
+fn main() -> Result<(), Box<dyn Error>> {
     // Dummy function to make the linter happy.
     Ok(())
 }


### PR DESCRIPTION
## Changes

This PR introduces centralized Rinf error type called `RinfError`, enabling more robust and reliable error-handling.

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_ffi_plugin --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
