### PR TITLE
Allow the main function in Rust to have any return type

### DIFF
--- a/rust_crate/src/interface.rs
+++ b/rust_crate/src/interface.rs
@@ -27,9 +27,10 @@ pub struct DartSignal<T> {
 /// the `Runtime` object itself might be moved between threads,
 /// along with all the tasks it manages.
 #[cfg(not(target_family = "wasm"))]
-pub fn start_rust_logic<F>(main_future: F) -> Result<(), RinfError>
+pub fn start_rust_logic<F, T>(main_future: F) -> Result<(), RinfError>
 where
-    F: Future<Output = ()> + Send + 'static,
+    F: Future<Output = T> + Send + 'static,
+    T: Send + 'static,
 {
     start_rust_logic_real(main_future)
 }
@@ -40,7 +41,7 @@ where
 #[cfg(target_family = "wasm")]
 pub fn start_rust_logic<F>(main_future: F) -> Result<(), RinfError>
 where
-    F: Future<Output = ()> + 'static,
+    F: Future + 'static,
 {
     start_rust_logic_real(main_future)
 }

--- a/rust_crate/src/interface_os.rs
+++ b/rust_crate/src/interface_os.rs
@@ -37,9 +37,10 @@ pub extern "C" fn prepare_isolate_extern(port: i64) {
 type ShutdownSenderLock = OnceLock<ThreadLocal<RefCell<Option<ShutdownSender>>>>;
 static SHUTDOWN_SENDER: ShutdownSenderLock = OnceLock::new();
 
-pub fn start_rust_logic_real<F>(main_future: F) -> Result<(), RinfError>
+pub fn start_rust_logic_real<F, T>(main_future: F) -> Result<(), RinfError>
 where
-    F: Future<Output = ()> + Send + 'static,
+    F: Future<Output = T> + Send + 'static,
+    T: Send + 'static,
 {
     // Enable backtrace output for panics.
     #[cfg(debug_assertions)]

--- a/rust_crate/src/interface_web.rs
+++ b/rust_crate/src/interface_web.rs
@@ -6,7 +6,7 @@ use wasm_bindgen_futures::spawn_local;
 
 pub fn start_rust_logic_real<F>(main_future: F) -> Result<(), RinfError>
 where
-    F: Future<Output = ()> + 'static,
+    F: Future + 'static,
 {
     // Add kind description for panics.
     #[cfg(debug_assertions)]
@@ -17,7 +17,9 @@ where
     }
 
     // Run the main function.
-    spawn_local(main_future);
+    spawn_local(async {
+        main_future.await;
+    });
 
     Ok(())
 }


### PR DESCRIPTION
## Changes

This PR allows the `main` function in Rust to have any return type.

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_ffi_plugin --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
