### PR TITLE
Add the `rust_serde` to the `rinf config` command output

### DIFF
--- a/flutter_ffi_plugin/bin/src/config.dart
+++ b/flutter_ffi_plugin/bin/src/config.dart
@@ -45,7 +45,8 @@ class RinfConfigMessage {
     return '''message:
     $KEY_INPUT_DIR: $inputDir
     $KEY_RUST_OUTPUT_DIR: $rustOutputDir
-    $KEY_DART_OUTPUT_DIR: $dartOutputDir''';
+    $KEY_DART_OUTPUT_DIR: $dartOutputDir
+    $KEY_RUST_SERDE: $rustSerde''';
   }
 
   static const KEY_INPUT_DIR = "input_dir";


### PR DESCRIPTION
## Changes

Add the `rust_serde` to the `rinf config` command output.

~~The `rust_serde` is really awesome, but I didn't even notice it before😭.~~

## Before Committing

```
dart analyze flutter_ffi_plugin --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
