### PR TITLE
feat: Support for marking "RUST-ATTRIBUTE" (type attribute)

### DIFF
--- a/documentation/docs/messaging.md
+++ b/documentation/docs/messaging.md
@@ -1,14 +1,18 @@
 # Messaging
 
-There are 2 types of special comments that you can mark messages with.
+There are special comments that you can mark messages with.
 
-## 📢 Rust Signal
+## 📢 Channels
 
-`[RINF:RUST-SIGNAL]` generates a channel from Rust to Dart.
+`[RINF:RUST-SIGNAL]` generates a message channel from Rust to Dart.
 
 ```proto title="Protobuf"
 // [RINF:RUST-SIGNAL]
 message MyDataOutput { ... }
+```
+
+```rust title="Rust"
+MyDataOutput { ... }.send_signal_to_dart();
 ```
 
 ```dart title="Dart"
@@ -25,15 +29,16 @@ StreamBuilder(
 )
 ```
 
-```rust title="Rust"
-MyDataOutput { ... }.send_signal_to_dart();
-```
-
 Use `[RINF:RUST-SIGNAL-BINARY]` to include binary data without the overhead of serialization.
 
 ```proto title="Protobuf"
 // [RINF:RUST-SIGNAL-BINARY]
 message MyDataOutput { ... }
+```
+
+```rust title="Rust"
+let binary: Vec<u8> = vec![0; 64];
+MyDataOutput { ... }.send_signal_to_dart(binary);
 ```
 
 ```dart title="Dart"
@@ -51,14 +56,7 @@ StreamBuilder(
 )
 ```
 
-```rust title="Rust"
-let binary: Vec<u8> = vec![0; 64];
-MyDataOutput { ... }.send_signal_to_dart(binary);
-```
-
-## 📭 Dart Signal
-
-`[RINF:DART-SIGNAL]` generates a channel from Dart to Rust.
+`[RINF:DART-SIGNAL]` generates a message channel from Dart to Rust.
 
 ```proto title="Protobuf"
 // [RINF:DART-SIGNAL]
@@ -96,4 +94,13 @@ while let Some(dart_signal) = receiver.recv().await {
     let binary: Vec<u8> = dart_signal.binary;
     // Custom Rust logic here
 }
+```
+
+## 🔖 Attributes
+
+`[RINF:RUST-ATTRIBUTE(...)]` writes an attribute above the generated message struct in Rust. This is useful when you want to automatically implement a trait for the message struct in Rust.
+
+```proto title="Protobuf"
+// [RINF:RUST-ATTRIBUTE(#[derive(Copy)])]
+message MyDataInput { ... }
 ```

--- a/flutter_ffi_plugin/bin/src/message.dart
+++ b/flutter_ffi_plugin/bin/src/message.dart
@@ -800,11 +800,12 @@ Future<Map<String, Map<String, List<MarkedMessage>>>> analyzeMarkedMessages(
           markType = MarkType.rustSignalBinary;
         }
 
+        // find [RINF:RUST-ATTRIBUTE(...)]
         var attr = attrExp.stringMatch(statement);
         if (attr != null) {
           markedMessages[subPath]![filename]!.add(MarkedMessage(
             MarkType.rustAttribute,
-            "--prost_opt=type_attribute=$filename.$messageName=$attr",
+            "--prost_opt=type_attribute=$filename.$messageName=${attr.replaceAll(",", "\\,")}",
             -1,
           ));
           continue;

--- a/flutter_ffi_plugin/bin/src/message.dart
+++ b/flutter_ffi_plugin/bin/src/message.dart
@@ -10,6 +10,7 @@ enum MarkType {
   dartSignalBinary,
   rustSignal,
   rustSignalBinary,
+  rustAttribute,
 }
 
 class MarkedMessage {
@@ -44,6 +45,12 @@ Future<void> generateMessageCode({
   await collectProtoFiles(
     Directory.fromUri(protoPath),
     Directory.fromUri(protoPath),
+    resourcesInFolders,
+  );
+
+  // Analyze marked messages in `.proto` files.
+  final markedMessagesAll = await analyzeMarkedMessages(
+    protoPath,
     resourcesInFolders,
   );
 
@@ -115,6 +122,12 @@ Future<void> generateMessageCode({
       '--prost_out=$rustFullPath',
       ...(messageConfig.rustSerde ? ['--prost-serde_out=$rustFullPath'] : []),
       ...resourceNames.map((name) => '$name.proto'),
+      ...markedMessagesAll.values.fold<List<String>>([], (args, messages) {
+        messages.values.forEach((messages) => args.addAll(messages
+            .where((message) => message.markType == MarkType.rustAttribute)
+            .map((message) => message.name)));
+        return args;
+      })
     ]);
     if (protocRustResult.exitCode != 0) {
       print(protocRustResult.stderr.toString().trim());
@@ -218,12 +231,6 @@ Future<void> generateMessageCode({
       throw Exception('Could not compile `.proto` files into Dart');
     }
   }
-
-  // Analyze marked messages in `.proto` files.
-  final markedMessagesAll = await analyzeMarkedMessages(
-    protoPath,
-    resourcesInFolders,
-  );
 
   // Prepare communication channels between Dart and Rust.
   for (final entry in markedMessagesAll.entries) {
@@ -761,6 +768,8 @@ Future<Map<String, Map<String, List<MarkedMessage>>>> analyzeMarkedMessages(
       );
       final content = await protoFile.readAsString();
       final regExp = RegExp(r'{[^}]*}');
+      final attrExp = RegExp(r"(?<=\[RINF:RUST-ATTRIBUTE\().*(?=\)\])");
+
       // Remove all { ... } blocks from the string
       final contentWithoutBlocks = content.replaceAll(regExp, ';');
       final statements = contentWithoutBlocks.split(";");
@@ -790,6 +799,17 @@ Future<Map<String, Map<String, List<MarkedMessage>>>> analyzeMarkedMessages(
         } else if (statement.contains("[RINF:RUST-SIGNAL-BINARY]")) {
           markType = MarkType.rustSignalBinary;
         }
+
+        var attr = attrExp.stringMatch(statement);
+        if (attr != null) {
+          markedMessages[subPath]![filename]!.add(MarkedMessage(
+            MarkType.rustAttribute,
+            "--prost_opt=type_attribute=$filename.$messageName=$attr",
+            -1,
+          ));
+          continue;
+        }
+
         if (markType == null) {
           // If there's no mark in the message, just ignore it
           continue;

--- a/flutter_ffi_plugin/example/messages/sample_folder/sample_file.proto
+++ b/flutter_ffi_plugin/example/messages/sample_folder/sample_file.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package enum_and_oneof;
+package sample_file;
 
 enum Kind {
   one = 0;
@@ -22,4 +22,9 @@ message SampleOutput {
     string name = 2;
     int32 age = 3;
   }
+}
+
+// [RINF:RUST-ATTRIBUTE(#[derive(Copy)])]
+message WithRustAttribute {
+  bool dummy = 1;
 }

--- a/flutter_ffi_plugin/example/native/hub/src/sample_functions.rs
+++ b/flutter_ffi_plugin/example/native/hub/src/sample_functions.rs
@@ -109,7 +109,7 @@ pub async fn stream_fractal() {
 // A dummy function that uses sample messages to eliminate warnings.
 #[allow(dead_code)]
 async fn use_messages() -> Result<()> {
-    use messages::sample_folder::enum_and_oneof::*;
+    use messages::sample_folder::sample_file::*;
     let _ = SampleInput::get_dart_signal_receiver()?;
     SampleOutput {
         kind: 3,


### PR DESCRIPTION
## Changes

Support pass extra args to `protoc`.

### Why

Sometimes, there is a need to add derives (#401) , if we use `protoc` to generate, we can pass some optional arguments,
 like `--prost_opt=type_attribute=Helloworld=#[derive(Foo)]`, but in rinf, we can't do the same.

This PR allows you to pass extra args to `protoc` and you can configure the extra args in `pubspec.yaml`.

### Usage

1. Configure in `pubspec.yaml`.

```yaml
rinf:
  message:
    extra_args: 
      - --prost_opt=type_attribute=SampleFractal=#[derive(Foo)]
```

2. Run `rinf message`

```diff
fractal_art.rs

// @generated
/// \[RINF:RUST-SIGNAL-BINARY\]
/// You can add your custom comments like this.
/// Protobuf's import statement also works well.
+ #[derive(Foo)]
#[allow(clippy::derive_partial_eq_without_eq)]
#[derive(Clone, PartialEq, ::prost::Message)]
pub struct SampleFractal {
...
```

FYI, https://github.com/neoeinstein/protoc-gen-prost/tree/main/protoc-gen-prost#options

## Before Committing

```
dart analyze flutter_ffi_plugin --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
