### PR TITLE
Applying the target family in the template similar to the project usage

### DIFF
--- a/flutter_ffi_plugin/template/native/hub/Cargo.toml
+++ b/flutter_ffi_plugin/template/native/hub/Cargo.toml
@@ -14,8 +14,11 @@ crate-type = ["lib", "cdylib", "staticlib"]
 [dependencies]
 rinf = "6.15.0"
 prost = "0.12.6"
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 tokio = { version = "1", features = ["sync", "rt"] }
 
-# Uncomment below to target the web.
-# tokio_with_wasm = { version = "0.6.0", features = ["sync", "rt"] }
-# wasm-bindgen = "0.2.92"
+# Web
+[target.'cfg(target_family = "wasm")'.dependencies]
+tokio_with_wasm = { version = "0.6.0", features = ["sync", "rt"] }
+wasm-bindgen = { version = "0.2.92" }

--- a/flutter_ffi_plugin/template/native/hub/src/lib.rs
+++ b/flutter_ffi_plugin/template/native/hub/src/lib.rs
@@ -5,8 +5,12 @@ mod common;
 mod messages;
 
 use crate::common::*;
-use tokio; // Comment this line to target the web.
-// use tokio_with_wasm::alias as tokio; // Uncomment this line to target the web.
+
+#[cfg(not(target_family = "wasm"))]
+use tokio;
+
+#[cfg(target_family = "wasm")]
+use tokio_with_wasm::alias as tokio;
 
 rinf::write_interface!();
 


### PR DESCRIPTION
## Changes

To make the project using the generated template to be able to build both wasm and no wasm runtimes

## Before Committing

_Please make sure that you've analyzed and formatted the files._

