### PR TITLE
Use new `LazyLock` to store message channels

### DIFF
--- a/documentation/docs/frequently-asked-questions.md
+++ b/documentation/docs/frequently-asked-questions.md
@@ -233,10 +233,10 @@ onPressed: () async {
 ```
 
 ```rust title="native/hub/src/sample_functions.rs"
-pub async fn respond() -> Result<()> {
+pub async fn respond() {
     use messages::tutorial_resource::*;
 
-    let receiver = MyUniqueInput::get_dart_signal_receiver()?;
+    let receiver = MyUniqueInput::get_dart_signal_receiver();
     while let Some(dart_signal) = receiver.recv().await {
         let my_unique_input = dart_signal.message;
         MyUniqueOutput {
@@ -245,8 +245,6 @@ pub async fn respond() -> Result<()> {
         }
         .send_signal_to_dart();
     }
-
-    Ok(())
 }
 ```
 

--- a/documentation/docs/messaging.md
+++ b/documentation/docs/messaging.md
@@ -68,7 +68,7 @@ MyDataInput( ... ).sendSignalToRust();
 ```
 
 ```rust title="Rust"
-let receiver = MyDataInput::get_dart_signal_receiver()?;
+let receiver = MyDataInput::get_dart_signal_receiver();
 while let Some(dart_signal) = receiver.recv().await {
     let message: MyDataInput = dart_signal.message;
     // Custom Rust logic here
@@ -88,7 +88,7 @@ MyDataInput( ... ).sendSignalToRust(binary);
 ```
 
 ```rust title="Rust"
-let receiver = MyDataInput::get_dart_signal_receiver()?;
+let receiver = MyDataInput::get_dart_signal_receiver();
 while let Some(dart_signal) = receiver.recv().await {
     let message: MyDataInput = dart_signal.message;
     let binary: Vec<u8> = dart_signal.binary;

--- a/documentation/docs/tutorial.md
+++ b/documentation/docs/tutorial.md
@@ -62,10 +62,10 @@ use crate::common::*;
 use crate::messages;
 use rinf::debug_print;
 
-pub async fn calculate_precious_data() -> Result<()> {
+pub async fn calculate_precious_data() {
     use messages::tutorial_messages::*;
 
-    let receiver = MyPreciousData::get_dart_signal_receiver()?; // GENERATED
+    let receiver = MyPreciousData::get_dart_signal_receiver(); // GENERATED
     while let Some(dart_signal) = receiver.recv().await {
         let my_precious_data = dart_signal.message;
 
@@ -79,8 +79,6 @@ pub async fn calculate_precious_data() -> Result<()> {
         debug_print!("{new_numbers:?}");
         debug_print!("{new_string}");
     }
-
-    Ok(())
 }
 ```
 
@@ -217,18 +215,16 @@ children: [
 use crate::common::*;
 use crate::messages;
 
-pub async fn tell_treasure() -> Result<()> {
+pub async fn tell_treasure() {
     use messages::tutorial_messages::*;
 
     let mut current_value: i32 = 1;
 
-    let receiver = MyTreasureInput::get_dart_signal_receiver()?; // GENERATED
+    let receiver = MyTreasureInput::get_dart_signal_receiver(); // GENERATED
     while let Some(_) = receiver.recv().await {
         MyTreasureOutput { current_value }.send_signal_to_dart(); // GENERATED
         current_value += 1;
     }
-
-    Ok(())
 }
 ```
 

--- a/flutter_package/example/native/hub/src/sample_functions.rs
+++ b/flutter_package/example/native/hub/src/sample_functions.rs
@@ -13,13 +13,13 @@ static IS_DEBUG_MODE: bool = true;
 static IS_DEBUG_MODE: bool = false;
 
 // Business logic for the counter widget.
-pub async fn tell_numbers() -> Result<()> {
+pub async fn tell_numbers() {
     use messages::counter_number::*;
 
     let mut vector = Vec::new();
 
     // Stream getter is generated from a marked Protobuf message.
-    let receiver = SampleNumberInput::get_dart_signal_receiver()?;
+    let receiver = SampleNumberInput::get_dart_signal_receiver();
     while let Some(dart_signal) = receiver.recv().await {
         // Extract values from the message received from Dart.
         // This message is a type that's declared in its Protobuf file.
@@ -40,8 +40,6 @@ pub async fn tell_numbers() -> Result<()> {
         }
         .send_signal_to_dart();
     }
-
-    Ok(())
 }
 
 // Business logic for the fractal image.
@@ -104,15 +102,14 @@ pub async fn stream_fractal() {
 
 // A dummy function that uses sample messages to eliminate warnings.
 #[allow(dead_code)]
-async fn use_messages() -> Result<()> {
+async fn use_messages() {
     use messages::sample_folder::sample_file::*;
-    let _ = SampleInput::get_dart_signal_receiver()?;
+    let _ = SampleInput::get_dart_signal_receiver();
     SampleOutput {
         kind: 3,
         oneof_input: Some(sample_output::OneofInput::Age(25)),
     }
     .send_signal_to_dart();
-    Ok(())
 }
 
 // Business logic for testing various crates.

--- a/flutter_package/template/native/hub/src/lib.rs
+++ b/flutter_package/template/native/hub/src/lib.rs
@@ -28,18 +28,16 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn communicate() -> Result<()> {
+async fn communicate() {
     use messages::basic::*;
 
     // Send signals to Dart like below.
     SmallNumber { number: 7 }.send_signal_to_dart();
 
     // Get receivers that listen to Dart signals like below.
-    let receiver = SmallText::get_dart_signal_receiver()?;
+    let receiver = SmallText::get_dart_signal_receiver();
     while let Some(dart_signal) = receiver.recv().await {
         let message: SmallText = dart_signal.message;
         rinf::debug_print!("{message:?}");
     }
-
-    Ok(())
 }

--- a/rust_crate/src/error.rs
+++ b/rust_crate/src/error.rs
@@ -7,11 +7,6 @@ pub enum RinfError {
     NoDartIsolate,
     LockShutdownReceiver,
     NoShutdownReceiver,
-    LockMessageChannel,
-    BrokenMessageChannel,
-    ClosedMessageChannel,
-    NoMessageChannel,
-    MessageReceiverTaken,
     DecodeMessage,
     NoSignalHandler,
 }
@@ -30,21 +25,6 @@ impl fmt::Display for RinfError {
             }
             RinfError::NoShutdownReceiver => {
                 write!(f, "Shutdown receiver was not created.")
-            }
-            RinfError::LockMessageChannel => {
-                write!(f, "Could not acquire the message channel lock.")
-            }
-            RinfError::BrokenMessageChannel => {
-                write!(f, "Message channel is broken.",)
-            }
-            RinfError::ClosedMessageChannel => {
-                write!(f, "Message channel is closed.",)
-            }
-            RinfError::NoMessageChannel => {
-                write!(f, "Message channel was not created.",)
-            }
-            RinfError::MessageReceiverTaken => {
-                write!(f, "Each Dart signal receiver can be taken only once.")
             }
             RinfError::DecodeMessage => {
                 write!(f, "Could not decode the message.")


### PR DESCRIPTION
## Changes

This PR makes message channels more efficient by using new `LazyLock` introduced in Rust 1.80

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_package --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
