### PR TITLE
Use leaf calls when possible to reduce memory copy

### DIFF
--- a/flutter_package/example/android/build.gradle
+++ b/flutter_package/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:8.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/flutter_package/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/flutter_package/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip

--- a/flutter_package/example/ios/Runner/AppDelegate.swift
+++ b/flutter_package/example/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/flutter_package/example/macos/Runner/AppDelegate.swift
+++ b/flutter_package/example/macos/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import Cocoa
 import FlutterMacOS
 
-@NSApplicationMain
+@main
 class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     return true

--- a/flutter_package/lib/rinf.dart
+++ b/flutter_package/lib/rinf.dart
@@ -1,6 +1,7 @@
 /// This module supports communication with Rust.
 library;
 
+import 'dart:ffi';
 import 'dart:typed_data';
 import 'src/exports.dart';
 
@@ -35,7 +36,9 @@ void sendDartSignal(
 ) async {
   sendDartSignalReal(
     messageId,
-    messageBytes,
-    binary,
+    messageBytes.address,
+    messageBytes.length,
+    binary.address,
+    binary.length,
   );
 }

--- a/flutter_package/lib/rinf.dart
+++ b/flutter_package/lib/rinf.dart
@@ -1,7 +1,6 @@
 /// This module supports communication with Rust.
 library;
 
-import 'dart:ffi';
 import 'dart:typed_data';
 import 'src/exports.dart';
 
@@ -36,9 +35,7 @@ void sendDartSignal(
 ) async {
   sendDartSignalReal(
     messageId,
-    messageBytes.address,
-    messageBytes.length,
-    binary.address,
-    binary.length,
+    messageBytes,
+    binary,
   );
 }

--- a/flutter_package/lib/src/interface_os.dart
+++ b/flutter_package/lib/src/interface_os.dart
@@ -15,6 +15,9 @@ void setCompiledLibPathReal(String path) {
 Future<void> prepareInterfaceReal(
   AssignRustSignal assignRustSignal,
 ) async {
+  // Load the native library.
+  loadRustLibrary();
+
   /// This should be called once at startup
   /// to enable `allo_isolate` to send data from the Rust side.
   storeDartPostCObjectReal(NativeApi.postCObject);

--- a/flutter_package/lib/src/interface_os.dart
+++ b/flutter_package/lib/src/interface_os.dart
@@ -53,10 +53,16 @@ Future<void> prepareInterfaceReal(
   prepareIsolateReal(rustSignalPort.sendPort.nativePort);
 }
 
-@Native<Void Function()>(isLeaf: true, symbol: 'start_rust_logic_extern')
+@Native<Void Function()>(
+  isLeaf: true,
+  symbol: 'start_rust_logic_extern',
+)
 external void startRustLogicReal();
 
-@Native<Void Function()>(isLeaf: true, symbol: 'stop_rust_logic_extern')
+@Native<Void Function()>(
+  isLeaf: true,
+  symbol: 'stop_rust_logic_extern',
+)
 external void stopRustLogicReal();
 
 typedef SendDartSignalReal = Void Function(
@@ -66,7 +72,10 @@ typedef SendDartSignalReal = Void Function(
   Pointer<Uint8>,
   UintPtr,
 );
-@Native<SendDartSignalReal>(isLeaf: true, symbol: 'send_dart_signal_extern')
+@Native<SendDartSignalReal>(
+  isLeaf: true,
+  symbol: 'send_dart_signal_extern',
+)
 external void sendDartSignalExtern(
   int messageId,
   Pointer<Uint8> messageBytesAddress,
@@ -89,7 +98,10 @@ void sendDartSignalReal(
   );
 }
 
-@Native<Void Function(Int64)>(isLeaf: true, symbol: 'prepare_isolate_extern')
+@Native<Void Function(Int64)>(
+  isLeaf: true,
+  symbol: 'prepare_isolate_extern',
+)
 external void prepareIsolateReal(
   int port,
 );

--- a/flutter_package/lib/src/interface_os.dart
+++ b/flutter_package/lib/src/interface_os.dart
@@ -1,7 +1,6 @@
 import 'dart:ffi';
 import 'dart:typed_data';
 import 'load_os.dart';
-import 'package:ffi/ffi.dart';
 import 'dart:async';
 import 'dart:isolate';
 import 'interface.dart';
@@ -18,14 +17,7 @@ Future<void> prepareInterfaceReal(
 ) async {
   /// This should be called once at startup
   /// to enable `allo_isolate` to send data from the Rust side.
-  final rustFunction = rustLibrary.lookupFunction<
-      Pointer Function(
-        Pointer<NativeFunction<Int8 Function(Int64, Pointer<Dart_CObject>)>>,
-      ),
-      Pointer Function(
-        Pointer<NativeFunction<Int8 Function(Int64, Pointer<Dart_CObject>)>>,
-      )>('store_dart_post_cobject');
-  rustFunction(NativeApi.postCObject);
+  storeDartPostCObjectReal(NativeApi.postCObject);
 
   // Prepare ports for communication over isolates.
   final rustSignalPort = ReceivePort();
@@ -58,56 +50,38 @@ Future<void> prepareInterfaceReal(
   prepareIsolateReal(rustSignalPort.sendPort.nativePort);
 }
 
-void startRustLogicReal() {
-  final rustFunction =
-      rustLibrary.lookupFunction<Void Function(), void Function()>(
-    'start_rust_logic_extern',
-  );
-  rustFunction();
-}
+@Native<Void Function()>(isLeaf: true, symbol: 'start_rust_logic_extern')
+external void startRustLogicReal();
 
-void stopRustLogicReal() {
-  final rustFunction =
-      rustLibrary.lookupFunction<Void Function(), void Function()>(
-    'stop_rust_logic_extern',
-  );
-  rustFunction();
-}
+@Native<Void Function()>(isLeaf: true, symbol: 'stop_rust_logic_extern')
+external void stopRustLogicReal();
 
-/// Sends bytes to Rust.
-Future<void> sendDartSignalReal(
+typedef SendDartSignalReal = Void Function(
+  Int32,
+  Pointer<Uint8>,
+  UintPtr,
+  Pointer<Uint8>,
+  UintPtr,
+);
+@Native<SendDartSignalReal>(isLeaf: true, symbol: 'send_dart_signal_extern')
+external void sendDartSignalReal(
   int messageId,
-  Uint8List messageBytes,
-  Uint8List binary,
-) async {
-  final Pointer<Uint8> messageMemory = malloc.allocate(messageBytes.length);
-  messageMemory.asTypedList(messageBytes.length).setAll(0, messageBytes);
+  Pointer<Uint8> messageBytesAddress,
+  int messageBytesLength,
+  Pointer<Uint8> binaryAddress,
+  int binaryLength,
+);
 
-  final Pointer<Uint8> binaryMemory = malloc.allocate(binary.length);
-  binaryMemory.asTypedList(binary.length).setAll(0, binary);
+@Native<Void Function(Int64)>(isLeaf: true, symbol: 'prepare_isolate_extern')
+external void prepareIsolateReal(
+  int port,
+);
 
-  final rustFunction = rustLibrary.lookupFunction<
-      Void Function(Int32, Pointer<Uint8>, UintPtr, Pointer<Uint8>, UintPtr),
-      void Function(int, Pointer<Uint8>, int, Pointer<Uint8>, int)>(
-    'send_dart_signal_extern',
-  );
-
-  rustFunction(
-    messageId,
-    messageMemory,
-    messageBytes.length,
-    binaryMemory,
-    binary.length,
-  );
-
-  malloc.free(messageMemory);
-  malloc.free(binaryMemory);
-}
-
-void prepareIsolateReal(int port) {
-  final rustFunction =
-      rustLibrary.lookupFunction<Void Function(Int64), void Function(int)>(
-    'prepare_isolate_extern',
-  );
-  rustFunction(port);
-}
+typedef InnerFunction = Int8 Function(Int64, Pointer<Dart_CObject>);
+@Native<Void Function(Pointer<NativeFunction<InnerFunction>>)>(
+  isLeaf: true,
+  symbol: 'store_dart_post_cobject',
+)
+external void storeDartPostCObjectReal(
+  Pointer<NativeFunction<InnerFunction>> postCObject,
+);

--- a/flutter_package/lib/src/interface_os.dart
+++ b/flutter_package/lib/src/interface_os.dart
@@ -64,13 +64,27 @@ typedef SendDartSignalReal = Void Function(
   UintPtr,
 );
 @Native<SendDartSignalReal>(isLeaf: true, symbol: 'send_dart_signal_extern')
-external void sendDartSignalReal(
+external void sendDartSignalExtern(
   int messageId,
   Pointer<Uint8> messageBytesAddress,
   int messageBytesLength,
   Pointer<Uint8> binaryAddress,
   int binaryLength,
 );
+
+void sendDartSignalReal(
+  int messageId,
+  Uint8List messageBytes,
+  Uint8List binary,
+) {
+  sendDartSignalExtern(
+    messageId,
+    messageBytes.address,
+    messageBytes.length,
+    binary.address,
+    binary.length,
+  );
+}
 
 @Native<Void Function(Int64)>(isLeaf: true, symbol: 'prepare_isolate_extern')
 external void prepareIsolateReal(

--- a/flutter_package/lib/src/load_os.dart
+++ b/flutter_package/lib/src/load_os.dart
@@ -55,7 +55,7 @@ typedef PostCObjectFn = NativeFunction<PostCObjectInner>;
 
 // Direct access to global function symbols loaded in the process.
 // These are available only if the native library is
-// loaded into global process with `RTLD_GLOBAL` configuration.
+// loaded into global space with `RTLD_GLOBAL` configuration.
 
 @Native<Void Function()>(
   isLeaf: true,

--- a/flutter_package/lib/src/load_os.dart
+++ b/flutter_package/lib/src/load_os.dart
@@ -1,5 +1,7 @@
 import 'dart:io' as io;
 import 'dart:ffi';
+import 'dart:typed_data';
+import 'package:ffi/ffi.dart';
 
 String? dynamicLibPath;
 
@@ -7,25 +9,209 @@ void setDynamicLibPath(String path) {
   dynamicLibPath = path;
 }
 
-void loadRustLibrary() {
+RustLibrary loadRustLibrary() {
   // Use provided dynamic library path if possible.
-  final path = dynamicLibPath;
-  if (path != null) {
-    DynamicLibrary.open(path);
-  }
-
   // Otherewise, use the default path.
-  if (io.Platform.isLinux) {
-    DynamicLibrary.open('libhub.so');
+  final path = dynamicLibPath;
+  DynamicLibrary lib;
+  if (path != null) {
+    lib = DynamicLibrary.open(path);
+  } else if (io.Platform.isLinux) {
+    lib = DynamicLibrary.open('libhub.so');
   } else if (io.Platform.isAndroid) {
-    DynamicLibrary.open('libhub.so');
+    lib = DynamicLibrary.open('libhub.so');
   } else if (io.Platform.isWindows) {
-    DynamicLibrary.open('hub.dll');
+    lib = DynamicLibrary.open('hub.dll');
   } else if (io.Platform.isIOS) {
-    DynamicLibrary.open('rinf.framework/rinf');
+    lib = DynamicLibrary.open('rinf.framework/rinf');
   } else if (io.Platform.isMacOS) {
-    DynamicLibrary.open('rinf.framework/rinf');
+    lib = DynamicLibrary.open('rinf.framework/rinf');
   } else {
     throw UnsupportedError('This operating system is not supported.');
+  }
+
+  if (io.Platform.isAndroid) {
+    // On Android, native library symbols are loaded in local space
+    // because of Flutter's `RTLD_LOCAL` behavior.
+    // Therefore we cannot use the efficient `RustLibraryNew`.
+    // - https://github.com/dart-lang/native/issues/923
+    return RustLibraryOld(lib);
+  } else {
+    // Native library symbols are loaded in global space
+    // thanks to Flutter's `RTLD_GLOBAL` behavior.
+    return RustLibraryNew();
+  }
+}
+
+// The central interface for calling native function.
+
+final rustLibrary = loadRustLibrary();
+
+// Common type aliases.
+// This is for better readability of the code.
+
+typedef PostCObjectInner = Int8 Function(Int64, Pointer<Dart_CObject>);
+typedef PostCObjectFn = NativeFunction<PostCObjectInner>;
+
+// Direct access to global function symbols loaded in the process.
+// These are available only if the native library is
+// loaded into global process with `RTLD_GLOBAL` configuration.
+
+@Native<Void Function()>(
+  isLeaf: true,
+  symbol: 'start_rust_logic_extern',
+)
+external void startRustLogicExtern();
+
+@Native<Void Function()>(
+  isLeaf: true,
+  symbol: 'stop_rust_logic_extern',
+)
+external void stopRustLogicExtern();
+
+typedef SendDartSignalExtern = Void Function(
+  Int32,
+  Pointer<Uint8>,
+  UintPtr,
+  Pointer<Uint8>,
+  UintPtr,
+);
+@Native<SendDartSignalExtern>(
+  isLeaf: true,
+  symbol: 'send_dart_signal_extern',
+)
+external void sendDartSignalExtern(
+  int messageId,
+  Pointer<Uint8> messageBytesAddress,
+  int messageBytesLength,
+  Pointer<Uint8> binaryAddress,
+  int binaryLength,
+);
+
+@Native<Void Function(Int64)>(
+  isLeaf: true,
+  symbol: 'prepare_isolate_extern',
+)
+external void prepareIsolateExtern(
+  int port,
+);
+
+@Native<Void Function(Pointer<PostCObjectFn>)>(
+  isLeaf: true,
+  symbol: 'store_dart_post_cobject',
+)
+external void storeDartPostCObjectExtern(
+  Pointer<PostCObjectFn> postCObject,
+);
+
+/// Abstract class for unifying the interface
+/// for calling native functions.
+abstract class RustLibrary {
+  void startRustLogic();
+  void stopRustLogic();
+  void sendDartSignal(
+    int messageId,
+    Uint8List messageBytes,
+    Uint8List binary,
+  );
+  void prepareIsolate(int port);
+  void storeDartPostCObject(Pointer<PostCObjectFn> postCObject);
+}
+
+/// Class for global native library symbols loaded with `RTLD_GLOBAL`.
+/// This is the efficient and ideal way to call native code.
+class RustLibraryNew extends RustLibrary {
+  void startRustLogic() {
+    startRustLogicExtern();
+  }
+
+  void stopRustLogic() {
+    stopRustLogicExtern();
+  }
+
+  void sendDartSignal(
+    int messageId,
+    Uint8List messageBytes,
+    Uint8List binary,
+  ) {
+    sendDartSignalExtern(
+      messageId,
+      messageBytes.address,
+      messageBytes.length,
+      binary.address,
+      binary.length,
+    );
+  }
+
+  void prepareIsolate(int port) {
+    prepareIsolateExtern(port);
+  }
+
+  void storeDartPostCObject(Pointer<PostCObjectFn> postCObject) {
+    storeDartPostCObjectExtern(postCObject);
+  }
+}
+
+/// Class for local native library symbols loaded with `RTLD_LOCAL`.
+/// This is relatively inefficient because `malloc.allocate` is required.
+/// `@Native` attributes can only used on global native symbols.
+class RustLibraryOld extends RustLibrary {
+  final DynamicLibrary lib;
+  RustLibraryOld(this.lib);
+
+  void storeDartPostCObject(Pointer<PostCObjectFn> postCObject) {
+    final rustFunction = lib.lookupFunction<
+        Pointer Function(Pointer<PostCObjectFn>),
+        Pointer Function(Pointer<PostCObjectFn>)>(
+      'store_dart_post_cobject',
+    );
+    rustFunction(postCObject);
+  }
+
+  void startRustLogic() {
+    final rustFunction = lib.lookupFunction<Void Function(), void Function()>(
+      'start_rust_logic_extern',
+    );
+    rustFunction();
+  }
+
+  void stopRustLogic() {
+    final rustFunction = lib.lookupFunction<Void Function(), void Function()>(
+      'stop_rust_logic_extern',
+    );
+    rustFunction();
+  }
+
+  void sendDartSignal(int messageId, Uint8List messageBytes, Uint8List binary) {
+    final Pointer<Uint8> messageMemory = malloc.allocate(messageBytes.length);
+    messageMemory.asTypedList(messageBytes.length).setAll(0, messageBytes);
+
+    final Pointer<Uint8> binaryMemory = malloc.allocate(binary.length);
+    binaryMemory.asTypedList(binary.length).setAll(0, binary);
+
+    final rustFunction = lib.lookupFunction<
+        Void Function(Int32, Pointer<Uint8>, UintPtr, Pointer<Uint8>, UintPtr),
+        void Function(int, Pointer<Uint8>, int, Pointer<Uint8>, int)>(
+      'send_dart_signal_extern',
+    );
+
+    rustFunction(
+      messageId,
+      messageMemory,
+      messageBytes.length,
+      binaryMemory,
+      binary.length,
+    );
+
+    malloc.free(messageMemory);
+    malloc.free(binaryMemory);
+  }
+
+  void prepareIsolate(int port) {
+    final rustFunction =
+        lib.lookupFunction<Void Function(Int64), void Function(int)>(
+      'prepare_isolate_extern',
+    );
+    rustFunction(port);
   }
 }

--- a/flutter_package/lib/src/load_os.dart
+++ b/flutter_package/lib/src/load_os.dart
@@ -120,6 +120,10 @@ abstract class RustLibrary {
 
 /// Class for global native library symbols loaded with `RTLD_GLOBAL`.
 /// This is the efficient and ideal way to call native code.
+/// `@Native` decorator with `isLeaf` parameter
+/// that enables the `Uint8List.address` syntax
+/// can only used on global native symbols.
+/// - https://github.com/dart-lang/sdk/issues/44589
 class RustLibraryNew extends RustLibrary {
   void startRustLogic() {
     startRustLogicExtern();
@@ -154,7 +158,6 @@ class RustLibraryNew extends RustLibrary {
 
 /// Class for local native library symbols loaded with `RTLD_LOCAL`.
 /// This is relatively inefficient because `malloc.allocate` is required.
-/// `@Native` attributes can only used on global native symbols.
 class RustLibraryOld extends RustLibrary {
   final DynamicLibrary lib;
   RustLibraryOld(this.lib);

--- a/flutter_package/lib/src/load_os.dart
+++ b/flutter_package/lib/src/load_os.dart
@@ -2,30 +2,29 @@ import 'dart:io' as io;
 import 'dart:ffi';
 
 String? dynamicLibPath;
-final rustLibrary = loadRustLibrary();
 
 void setDynamicLibPath(String path) {
   dynamicLibPath = path;
 }
 
-DynamicLibrary loadRustLibrary() {
+void loadRustLibrary() {
   // Use provided dynamic library path if possible.
   final path = dynamicLibPath;
   if (path != null) {
-    return DynamicLibrary.open(path);
+    DynamicLibrary.open(path);
   }
 
   // Otherewise, use the default path.
   if (io.Platform.isLinux) {
-    return DynamicLibrary.open('libhub.so');
+    DynamicLibrary.open('libhub.so');
   } else if (io.Platform.isAndroid) {
-    return DynamicLibrary.open('libhub.so');
+    DynamicLibrary.open('libhub.so');
   } else if (io.Platform.isWindows) {
-    return DynamicLibrary.open('hub.dll');
+    DynamicLibrary.open('hub.dll');
   } else if (io.Platform.isIOS) {
-    return DynamicLibrary.open('rinf.framework/rinf');
+    DynamicLibrary.open('rinf.framework/rinf');
   } else if (io.Platform.isMacOS) {
-    return DynamicLibrary.open('rinf.framework/rinf');
+    DynamicLibrary.open('rinf.framework/rinf');
   } else {
     throw UnsupportedError('This operating system is not supported.');
   }

--- a/flutter_package/pubspec.yaml
+++ b/flutter_package/pubspec.yaml
@@ -4,8 +4,8 @@ version: 6.15.0
 repository: https://github.com/cunarist/rinf
 
 environment:
-  sdk: ">=3.0.5 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.5.0 <4.0.0"
+  flutter: ">=3.22.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Changes

This PR reduces memory copy while sending messages from Dart to Rust

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_package --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
