### PR TITLE
Shorten docs

### DIFF
--- a/documentation/docs/messaging.md
+++ b/documentation/docs/messaging.md
@@ -4,7 +4,7 @@ There are special comments that you can mark messages with.
 
 ## 📢 Channels
 
-`[RUST-SIGNAL]` generates a message channel from Rust to Dart.
+`[RUST-SIGNAL]` generates a message channel from Rust to Dart. Use `[RUST-SIGNAL-BINARY]` to include binary data without the overhead of serialization.
 
 ```proto title="Protobuf"
 // [RUST-SIGNAL]
@@ -24,39 +24,14 @@ StreamBuilder(
       // Return an empty widget.
     }
     MyDataOutput message = rustSignal.message;
-    // Return a filled widget.
-  },
-)
-```
-
-Use `[RUST-SIGNAL-BINARY]` to include binary data without the overhead of serialization.
-
-```proto title="Protobuf"
-// [RUST-SIGNAL-BINARY]
-message MyDataOutput { ... }
-```
-
-```rust title="Rust"
-let binary: Vec<u8> = vec![0; 64];
-MyDataOutput { ... }.send_signal_to_dart(binary);
-```
-
-```dart title="Dart"
-StreamBuilder(
-  stream: MyDataOutput.rustSignalStream,
-  builder: (context, snapshot) {
-    final rustSignal = snapshot.data;
-    if (rustSignal == null) {
-      // Return an empty widget.
-    }
-    MyDataOutput message = rustSignal.message;
+    // Below requires `[RUST-SIGNAL-BINARY]`.
     Uint8List binary = rustSignal.binary;
     // Return a filled widget.
   },
 )
 ```
 
-`[DART-SIGNAL]` generates a message channel from Dart to Rust.
+`[DART-SIGNAL]` generates a message channel from Dart to Rust. Use `[DART-SIGNAL-BINARY]` to include binary data without the overhead of serialization.
 
 ```proto title="Protobuf"
 // [DART-SIGNAL]
@@ -71,28 +46,9 @@ MyDataInput( ... ).sendSignalToRust();
 let receiver = MyDataInput::get_dart_signal_receiver();
 while let Some(dart_signal) = receiver.recv().await {
     let message: MyDataInput = dart_signal.message;
-    // Custom Rust logic here
-}
-```
-
-Use `[DART-SIGNAL-BINARY]` to include binary data without the overhead of serialization.
-
-```proto title="Protobuf"
-// [DART-SIGNAL-BINARY]
-message MyDataInput { ... }
-```
-
-```dart title="Dart"
-final binary = Uint8List(64);
-MyDataInput( ... ).sendSignalToRust(binary);
-```
-
-```rust title="Rust"
-let receiver = MyDataInput::get_dart_signal_receiver();
-while let Some(dart_signal) = receiver.recv().await {
-    let message: MyDataInput = dart_signal.message;
+    // Below requires `[DART-SIGNAL-BINARY]`.
     let binary: Vec<u8> = dart_signal.binary;
-    // Custom Rust logic here
+    // Custom Rust logic goes here.
 }
 ```
 

--- a/documentation/docs/state-management.md
+++ b/documentation/docs/state-management.md
@@ -2,7 +2,7 @@
 
 This section provides a general guide on effectively managing application state while using Rinf. It is not an introduction to a specific feature of Rinf.
 
-Rinf performs best when the application logic is written entirely in Rust, with Flutter used solely for the GUI. In such cases, you might want to store the application state in Rust.
+Rinf performs best when the application logic is written entirely in Rust, with Flutter used solely for the GUI. Given that, you might want to store the application state in Rust.
 
 ## 💥 Actor Model
 

--- a/documentation/docs/state-management.md
+++ b/documentation/docs/state-management.md
@@ -1,6 +1,6 @@
 # State Management
 
-This section provides a general guide on effectively managing application state while using Rinf. It is not an introduction to a specific feature of Rinf.
+This section offers a general guide to managing application state effectively with Rinf, rather than introducing a specific Rinf feature.
 
 Rinf performs best when the application logic is written entirely in Rust, with Flutter used solely for the GUI. Given that, you might want to store the application state in Rust.
 

--- a/flutter_package/example/native/hub/src/common.rs
+++ b/flutter_package/example/native/hub/src/common.rs
@@ -4,4 +4,7 @@ use std::error::Error;
 /// that implements the `Error` trait.
 /// In practice, it is recommended to use custom solutions
 /// or crates like `anyhow` dedicated to error handling.
+/// Building an app differs from writing a library, as apps
+/// may encounter numerous error situations, which is why
+/// a single, flexible error type is needed.
 pub type Result<T> = std::result::Result<T, Box<dyn Error + Send + Sync>>;

--- a/flutter_package/example/native/hub/src/common.rs
+++ b/flutter_package/example/native/hub/src/common.rs
@@ -3,5 +3,5 @@ use std::error::Error;
 /// This `Result` type alias allows handling any error type
 /// that implements the `Error` trait.
 /// In practice, it is recommended to use custom solutions
-/// or crates dedicated to error handling.
+/// or crates like `anyhow` dedicated to error handling.
 pub type Result<T> = std::result::Result<T, Box<dyn Error + Send + Sync>>;


### PR DESCRIPTION
## Changes

This PR shortens unnecessarily long sentences in the docs. It also clarifies some comments.

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_package --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
