### PR TITLE
Allow some optimization

### DIFF
--- a/rust_crate/src/channel.rs
+++ b/rust_crate/src/channel.rs
@@ -52,8 +52,8 @@ impl<T> SignalSender<T> {
 impl<T> SignalReceiver<T> {
     /// Asynchronously receives the next message from the queue. Only the active
     /// receiver is allowed to receive messages. If there are no messages in the
-    /// queue, the receiver will wait until a new message is sent. If this receiver
-    /// is not active, it will return `None`.
+    /// queue, the receiver will wait until a new message is sent.
+    /// If this receiver is not active, the future will return `None`.
     pub fn recv(&self) -> impl Future<Output = Option<T>> {
         RecvFuture {
             inner: self.inner.clone(),

--- a/rust_crate/src/channel.rs
+++ b/rust_crate/src/channel.rs
@@ -54,12 +54,11 @@ impl<T> SignalReceiver<T> {
     /// receiver is allowed to receive messages. If there are no messages in the
     /// queue, the receiver will wait until a new message is sent. If this receiver
     /// is not active, it will return `None`.
-    pub async fn recv(&self) -> Option<T> {
+    pub fn recv(&self) -> impl Future<Output = Option<T>> {
         RecvFuture {
             inner: self.inner.clone(),
             receiver_id: self.id, // Pass the receiver's ID to the future
         }
-        .await
     }
 }
 

--- a/rust_crate/src/shutdown.rs
+++ b/rust_crate/src/shutdown.rs
@@ -29,8 +29,8 @@ pub struct ShutdownEvents {
 /// Awaiting this receiver in the async main Rust function
 /// is necessary to prevent the async runtime in Rust from
 /// finishing immediately.
-pub async fn dart_shutdown() {
-    SHUTDOWN_EVENTS.dart_stopped.wait_async().await;
+pub fn dart_shutdown() -> impl Future<Output = ()> {
+    SHUTDOWN_EVENTS.dart_stopped.wait_async()
 }
 
 /// Synchronization primitive that allows


### PR DESCRIPTION
Add a method that allows better performance. The future can be reused for each message and efficiently polled without unsafe code and unnecessary allocations.