### PR TITLE
Correction of nested folder structure reference error when creating message for rust

### DIFF
--- a/flutter_package/bin/src/message.dart
+++ b/flutter_package/bin/src/message.dart
@@ -146,7 +146,7 @@ Future<void> generateMessageCode({
     final resourceNames = entry.value;
     final modRsLines = <String>[];
     for (final resourceName in resourceNames) {
-      modRsLines.add('mod $resourceName;');
+      modRsLines.add('pub mod $resourceName;');
       modRsLines.add('pub use $resourceName::*;');
     }
     for (final otherSubPath in resourcesInFolders.keys) {


### PR DESCRIPTION
## Changes

Situation

When I used the nested folder, I took the proto file in it, but it was not referenced after the rinf message, so there was an error.

Solution

When I analyzed the file generation, it would be solved if you just share the file name. So I used a method of sharing only the same file name with a pub. However, the concern is that the name of the proto file is the same, but when I tested it separately, I confirmed that if the same name is used, it will be overwritten