### PR TITLE
Switch to `uv` for Python dependency resolution

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -10,7 +10,7 @@ _Please describe the exact steps to reproduce the error._
 
 _Please provide the output from the command below, using markdown codeblock syntax._
 
-```bash
+```shell
 rustc --version
 flutter doctor
 ```

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ target/
 # Others
 *.lock
 /documentation/site/
+.python-version

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,27 +1,15 @@
 # Documentation
 
-In order to preview and build this documentation, you need to have Python and [Poetry](https://python-poetry.org/docs/) installed on your system.
+In order to preview and build this documentation, ensure you have [`uv`](https://docs.astral.sh/uv/getting-started/installation/), the modern Python package manager, installed on your system.
 
-Activate the virtual environment.
+Activate test server during development.
 
-```bash
-poetry shell
-```
-
-Install Python dependencies.
-
-```bash
-poetry install
+```shell
+uv run mkdocs serve
 ```
 
 Activate test server during development.
 
-```bash
-mkdocs serve
-```
-
-Activate test server during development.
-
-```bash
-mkdocs build
+```shell
+uv run mkdocs build
 ```

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -8,7 +8,7 @@ Activate test server during development.
 uv run mkdocs serve
 ```
 
-Activate test server during development.
+Build the documentation.
 
 ```shell
 uv run mkdocs build

--- a/documentation/docs/applying-template.md
+++ b/documentation/docs/applying-template.md
@@ -6,7 +6,7 @@
 
 First of all, add this framework to your Flutter project.
 
-```bash title="CLI"
+```shell title="CLI"
 flutter pub add rinf
 ```
 
@@ -14,7 +14,7 @@ Now install the command executable to easily run Rinf commands in the CLI.[^1]
 
 [^1]: If you're curious about all the available commands, use `rinf --help`.
 
-```bash title="CLI"
+```shell title="CLI"
 cargo install rinf
 ```
 
@@ -22,7 +22,7 @@ Then, simply run this in the command-line[^2] from your Flutter project's direct
 
 [^2]: If you encounter issues with the automated `protoc` installation, likely due to GitHub API access restrictions, you can [manually install it](https://grpc.io/docs/protoc-installation/) on your machine and add it to PATH. You can verify the installation by running the command `protoc --version` to ensure that the Protobuf compiler is ready on your machine. Rinf will detect and use the manually installed `protoc` if it exists.
 
-```bash title="CLI"
+```shell title="CLI"
 rinf template
 ```
 

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -15,7 +15,7 @@ rinf:
 
 You can check the current configuration status by running the command below in the CLI.
 
-```bash title="CLI"
+```shell title="CLI"
 rinf config
 ```
 

--- a/documentation/docs/detailed-techniques.md
+++ b/documentation/docs/detailed-techniques.md
@@ -11,6 +11,7 @@ We've covered how to pass signals[^1] between Dart and Rust in the previous tuto
 It's important to note that creating a Protobuf `message` larger than a few megabytes is not recommended. For large data, split them into multiple signals, or use the `binary` field instead.[^2]
 
 [^1]: Rinf relies solely on native FFI for communication, avoiding the use of web protocols or hidden threads. The goal is to minimize performance overhead as much as possible.
+
 [^2]: Sending a serialized message or binary data is a zero-copy operation from Rust to Dart, while it involves a copy operation from Dart to Rust in memory. Keep in mind that Protobuf's serialization and deserialization does involve memory copy.
 
 ## 🗃️ Generation Path

--- a/documentation/docs/detailed-techniques.md
+++ b/documentation/docs/detailed-techniques.md
@@ -11,7 +11,6 @@ We've covered how to pass signals[^1] between Dart and Rust in the previous tuto
 It's important to note that creating a Protobuf `message` larger than a few megabytes is not recommended. For large data, split them into multiple signals, or use the `binary` field instead.[^2]
 
 [^1]: Rinf relies solely on native FFI for communication, avoiding the use of web protocols or hidden threads. The goal is to minimize performance overhead as much as possible.
-
 [^2]: Sending a serialized message or binary data is a zero-copy operation from Rust to Dart, while it involves a copy operation from Dart to Rust in memory. Keep in mind that Protobuf's serialization and deserialization does involve memory copy.
 
 ## 🗃️ Generation Path
@@ -26,7 +25,7 @@ When you generate message code using the `rinf message` command, the resulting D
 
 If you add the optional argument `-w` or `--watch` to the `rinf message` command, the message code will be automatically generated when `.proto` files are modified. If you add this argument, the command will not exit on its own.
 
-```bash title="CLI"
+```shell title="CLI"
 rinf message --watch
 ```
 

--- a/documentation/docs/frequently-asked-questions.md
+++ b/documentation/docs/frequently-asked-questions.md
@@ -95,7 +95,7 @@ Ensure that you import the necessary well-known type(s) at the beginning of your
 
 Open your terminal and navigate to the root directory of your Dart project. Then, use the `protoc` command to compile the well-known type to Dart. For example, to compile the `Timestamp` type, you can run the following command:
 
-```bash title="CLI"
+```shell title="CLI"
 protoc --dart_out=./lib/messages google/protobuf/timestamp.proto
 ```
 
@@ -161,7 +161,7 @@ Exception: Unable to generate build files
 
 This error can simply be fixed with the command below.
 
-```bash title="CLI"
+```shell title="CLI"
 flutter clean
 cargo clean
 ```

--- a/documentation/docs/installing-components.md
+++ b/documentation/docs/installing-components.md
@@ -6,7 +6,7 @@ To get started, you need to have [Flutter SDK](https://docs.flutter.dev/get-star
 
 Once you're done with the installations, verify your system's readiness with the following commands. Make sure you have installed all the subcomponents that Flutter suggests. If there are no issues in the output, you are good to go onto the next step!
 
-```bash title="CLI"
+```shell title="CLI"
 rustc --version
 flutter doctor
 ```

--- a/documentation/docs/running-and-building.md
+++ b/documentation/docs/running-and-building.md
@@ -27,6 +27,7 @@ You need to manually build webassembly module from Rust before running or buildi
 To serve[^3] the web application[^4]:
 
 [^3]: Note that Flutter apps in debug mode are known to be quite slow on the web. It is recommended to use profile mode when testing on a web browser.
+
 [^4]: Since repeatedly writing web header arguments during development can be overwhelming, Rinf provides a convenient command `rinf server` that prints the full Flutter web command.
 
 ```shell title="CLI"

--- a/documentation/docs/running-and-building.md
+++ b/documentation/docs/running-and-building.md
@@ -8,13 +8,13 @@ The following commands are just enough to run and build apps for native platform
 
 To run the app:
 
-```bash title="CLI"
+```shell title="CLI"
 flutter run
 ```
 
 To build the app for a specific platform:
 
-```bash title="CLI"
+```shell title="CLI"
 flutter build [platform] # Replace it with a platform name
 ```
 
@@ -27,10 +27,9 @@ You need to manually build webassembly module from Rust before running or buildi
 To serve[^3] the web application[^4]:
 
 [^3]: Note that Flutter apps in debug mode are known to be quite slow on the web. It is recommended to use profile mode when testing on a web browser.
-
 [^4]: Since repeatedly writing web header arguments during development can be overwhelming, Rinf provides a convenient command `rinf server` that prints the full Flutter web command.
 
-```bash title="CLI"
+```shell title="CLI"
 rinf wasm
 flutter run --web-header=Cross-Origin-Opener-Policy=same-origin --web-header=Cross-Origin-Embedder-Policy=require-corp
 ```
@@ -39,7 +38,7 @@ To build the optimized release version of the web application[^5]:
 
 [^5]: Rinf supports hosting a Flutter app at a [non-root location](https://docs.flutter.dev/ui/navigation/url-strategies#hosting-a-flutter-app-at-a-non-root-location). For example, you can place your Flutter app in `https://mywebsite.com/subpath/deeperpath/`.
 
-```bash title="CLI"
+```shell title="CLI"
 rinf wasm --release
 flutter build web
 ```

--- a/documentation/docs/tutorial.md
+++ b/documentation/docs/tutorial.md
@@ -30,7 +30,7 @@ message MyPreciousData {
 
 Next, generate Dart and Rust message code from `.proto` files.
 
-```bash title="CLI"
+```shell title="CLI"
 rinf message
 ```
 
@@ -113,7 +113,7 @@ message MyAmazingNumber { int32 current_number = 1; }
 
 Generate Dart and Rust message code from `.proto` files.
 
-```bash title="CLI"
+```shell title="CLI"
 rinf message
 ```
 
@@ -183,7 +183,7 @@ message MyTreasureInput {}
 message MyTreasureOutput { int32 current_value = 1; }
 ```
 
-```bash title="CLI"
+```shell title="CLI"
 rinf message
 ```
 

--- a/documentation/docs/upgrading.md
+++ b/documentation/docs/upgrading.md
@@ -37,6 +37,6 @@ use crate::messages::*;
 
 When you need to run a Flutter web server, use `rinf server` to get the complete Flutter command with the necessary arguments.
 
-```bash title="CLI"
+```shell title="CLI"
 rinf server
 ```

--- a/documentation/pyproject.toml
+++ b/documentation/pyproject.toml
@@ -1,10 +1,11 @@
-[tool.poetry]
-package-mode = false
-
-[tool.poetry.dependencies]
-python = "^3.10"
-mkdocs = "^1.6.1"
-mkdocs-material = "^9.5.34"
-mkdocs-awesome-pages-plugin = "^2.9.3"
-mkdocs-glightbox = "^0.4.0"
-mkdocs-git-revision-date-localized-plugin = "^1.2.9"
+[project]
+name = "rinf-documentation"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "mkdocs~=1.6.1",
+    "mkdocs-material~=9.5.34",
+    "mkdocs-awesome-pages-plugin~=2.9.3",
+    "mkdocs-glightbox~=0.4.0",
+    "mkdocs-git-revision-date-localized-plugin~=1.2.9",
+]

--- a/flutter_package/bin/src/helpers.dart
+++ b/flutter_package/bin/src/helpers.dart
@@ -105,14 +105,14 @@ installed on your system.
 You can check that your system is ready with the commands below.
 Note that all the Flutter subcomponents should be installed.
 
-```bash
+```shell
 rustc --version
 flutter doctor
 ```
 
 You also need to have the CLI tool for Rinf ready.
 
-```bash
+```shell
 cargo install rinf
 ```
 
@@ -121,13 +121,13 @@ If you have newly cloned the project repository
 or made changes to the `.proto` files in the `./messages` directory,
 run the following command:
 
-```bash
+```shell
 rinf message
 ```
 
 Now you can run and build this app just like any other Flutter projects.
 
-```bash
+```shell
 flutter run
 ```
 

--- a/flutter_package/example/README.md
+++ b/flutter_package/example/README.md
@@ -15,14 +15,14 @@ installed on your system.
 You can check that your system is ready with the commands below.
 Note that all the Flutter subcomponents should be installed.
 
-```bash
+```shell
 rustc --version
 flutter doctor
 ```
 
 You also need to have the CLI tool for Rinf ready.
 
-```bash
+```shell
 cargo install rinf
 ```
 
@@ -31,13 +31,13 @@ If you have newly cloned the project repository
 or made changes to the `.proto` files in the `./messages` directory,
 run the following command:
 
-```bash
+```shell
 rinf message
 ```
 
 Now you can run and build this app just like any other Flutter projects.
 
-```bash
+```shell
 flutter run
 ```
 


### PR DESCRIPTION
## Changes

Now we use `uv` instead of Poetry for Python dependency resolution.

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_package --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
