### PR TITLE
docs: warn about flutter snap package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ target/
 *.lock
 /documentation/site/
 .python-version
+
+# editable python install artifacts
+documentation/*.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,6 @@ target/
 
 # Others
 *.lock
-/documentation/site/
 .python-version
-
-# editable python install artifacts
-documentation/*.egg-info/
+/documentation/site/
+/documentation/*.egg-info/

--- a/documentation/docs/installing-components.md
+++ b/documentation/docs/installing-components.md
@@ -1,8 +1,14 @@
 # Installing Components
 
-To get started, you need to have [Flutter SDK](https://docs.flutter.dev/get-started/install)[^1] and [Rust toolchain](https://www.rust-lang.org/tools/install) installed on your system.
+[flutter-install-steps]: https://docs.flutter.dev/get-started/install
 
-[^1]: If you're working on Linux, do not install Flutter from `snap`. Flutter from `snap` comes with its own binary linker called `ld`, which is fundamentally incompatible with Rust. Instead, follow the manual installation method as written in the Flutter docs.
+To get started, you need to have [Flutter SDK][flutter-install-steps] and [Rust toolchain](https://www.rust-lang.org/tools/install) installed on your system.
+
+!!! warning "Flutter SDK snap package will not work"
+
+    If you're working on Linux, do not install Flutter from `snap`. Flutter from `snap` comes with its own binary linker called `ld`, which is fundamentally incompatible with Rust. Instead, follow the [manual installation steps per the Flutter docs][flutter-install-steps].
+
+    Typically, the Flutter SDK package found in Debian-based Linux distributions' app store (under the name "Flutter") is a snap package.
 
 Once you're done with the installations, verify your system's readiness with the following commands. Make sure you have installed all the subcomponents that Flutter suggests. If there are no issues in the output, you are good to go onto the next step!
 

--- a/documentation/docs/installing-components.md
+++ b/documentation/docs/installing-components.md
@@ -1,6 +1,8 @@
 # Installing Components
 
-To get started, you need to have [Flutter SDK](https://docs.flutter.dev/get-started/install) and [Rust toolchain](https://www.rust-lang.org/tools/install) installed on your system.
+[flutter-install-steps]: https://docs.flutter.dev/get-started/install
+
+To get started, you need to have [Flutter SDK][flutter-install-steps] and [Rust toolchain](https://www.rust-lang.org/tools/install) installed on your system.
 
 Once you're done with the installations, verify your system's readiness with the following commands. Make sure you have installed all the subcomponents that Flutter suggests. If there are no issues in the output, you are good to go onto the next step!
 

--- a/documentation/docs/installing-components.md
+++ b/documentation/docs/installing-components.md
@@ -15,6 +15,6 @@ flutter doctor
 
     If you're working on Linux, it is recommended to install Flutter manually. Do not install Flutter from `snap`.
 
-    Flutter from `snap` comes with its own binary linker called `ld`, which is fundamentally incompatible with Rust. Instead, follow the [manual installation steps per the Flutter docs](https://docs.flutter.dev/get-started/install/linux).
+    Flutter from `snap` comes with its own binary linker called `ld`, which is fundamentally incompatible with Rust. Instead, follow the [manual installation steps per the Flutter docs][flutter-install-steps].
 
     Typically, the Flutter SDK package found in Debian-based Linux distributions' app store (under the name "Flutter") is a `snap` package.

--- a/documentation/docs/installing-components.md
+++ b/documentation/docs/installing-components.md
@@ -11,6 +11,8 @@ flutter doctor
 
 !!! warning
 
-    If you're working on Linux, do not install Flutter from `snap`. Flutter from `snap` comes with its own binary linker called `ld`, which is fundamentally incompatible with Rust. Instead, follow the [manual installation steps per the Flutter docs][flutter-install-steps].
+    If you're working on Linux, it is recommended to install Flutter manually. Do not install Flutter from `snap`.
 
-    Typically, the Flutter SDK package found in Debian-based Linux distributions' app store (under the name 'Flutter') is a snap package.
+    Flutter from `snap` comes with its own binary linker called `ld`, which is fundamentally incompatible with Rust. Instead, follow the [manual installation steps per the Flutter docs](https://docs.flutter.dev/get-started/install/linux).
+
+    Typically, the Flutter SDK package found in Debian-based Linux distributions' app store (under the name "Flutter") is a `snap` package.

--- a/documentation/docs/installing-components.md
+++ b/documentation/docs/installing-components.md
@@ -1,8 +1,6 @@
 # Installing Components
 
-[flutter-install-steps]: https://docs.flutter.dev/get-started/install
-
-To get started, you need to have [Flutter SDK][flutter-install-steps] and [Rust toolchain](https://www.rust-lang.org/tools/install) installed on your system.
+To get started, you need to have [Flutter SDK](https://docs.flutter.dev/get-started/install) and [Rust toolchain](https://www.rust-lang.org/tools/install) installed on your system.
 
 Once you're done with the installations, verify your system's readiness with the following commands. Make sure you have installed all the subcomponents that Flutter suggests. If there are no issues in the output, you are good to go onto the next step!
 

--- a/documentation/docs/installing-components.md
+++ b/documentation/docs/installing-components.md
@@ -4,15 +4,15 @@
 
 To get started, you need to have [Flutter SDK][flutter-install-steps] and [Rust toolchain](https://www.rust-lang.org/tools/install) installed on your system.
 
-!!! warning "Flutter SDK snap package will not work"
-
-    If you're working on Linux, do not install Flutter from `snap`. Flutter from `snap` comes with its own binary linker called `ld`, which is fundamentally incompatible with Rust. Instead, follow the [manual installation steps per the Flutter docs][flutter-install-steps].
-
-    Typically, the Flutter SDK package found in Debian-based Linux distributions' app store (under the name "Flutter") is a snap package.
-
 Once you're done with the installations, verify your system's readiness with the following commands. Make sure you have installed all the subcomponents that Flutter suggests. If there are no issues in the output, you are good to go onto the next step!
 
 ```shell title="CLI"
 rustc --version
 flutter doctor
 ```
+
+!!! warning
+
+    If you're working on Linux, do not install Flutter from `snap`. Flutter from `snap` comes with its own binary linker called `ld`, which is fundamentally incompatible with Rust. Instead, follow the [manual installation steps per the Flutter docs][flutter-install-steps].
+
+    Typically, the Flutter SDK package found in Debian-based Linux distributions' app store (under the name 'Flutter') is a snap package.


### PR DESCRIPTION
resolves #498

## Changes

This replaces a footnote (about avoiding the flutter snap package) with an admonition and notes that app stores (at least on debian-based Linux distros) offer flutter SDK as a snap package.