### PR TITLE
Rustfmt messages

### DIFF
--- a/flutter_package/bin/src/message.dart
+++ b/flutter_package/bin/src/message.dart
@@ -487,13 +487,18 @@ pub fn assign_dart_signal(
       .writeAsString(rustReceiveScript);
 
   // format rust code
-  var rustFiles = resourcesInFolders.keys.toList();
-  rustFiles.addAll(['generated.rs', 'mod.rs']);
-  rustFiles = rustFiles
-      .map((rsFile) => rustOutputPath.join(rsFile).toFilePath())
-      .toList();
-  await Process.run(
-      'cargo', ['fmt', '--', for (final rsFile in rustFiles) rsFile]);
+  var rustFiles = <String>[];
+  for (final entry in resourcesInFolders.entries) {
+    for (final file in entry.value) {
+      rustFiles.add(
+        rustOutputPath.join(entry.key).join('$file.rs').toFilePath(),
+      );
+    }
+  }
+  for (final rootMod in ['generated.rs', 'mod.rs']) {
+    rustFiles.add(rustOutputPath.join(rootMod).toFilePath());
+  }
+  await Process.run('rustfmt', rustFiles);
 
   // Get ready to handle received signals in Dart.
   var dartReceiveScript = '';

--- a/flutter_package/bin/src/message.dart
+++ b/flutter_package/bin/src/message.dart
@@ -191,6 +191,7 @@ Future<void> generateMessageCode({
     await File.fromUri(rustOutputPath.join(subPath).join('mod.rs'))
         .writeAsString(modRsContent);
   }
+
   fillingBar.increment();
 
   // Generate Dart message files.
@@ -484,6 +485,15 @@ pub fn assign_dart_signal(
 ''';
   await File.fromUri(rustOutputPath.join('generated.rs'))
       .writeAsString(rustReceiveScript);
+
+  // format rust code
+  var rustFiles = resourcesInFolders.keys.toList();
+  rustFiles.addAll(['generated.rs', 'mod.rs']);
+  rustFiles = rustFiles
+      .map((rsFile) => rustOutputPath.join(rsFile).toFilePath())
+      .toList();
+  await Process.run(
+      'cargo', ['fmt', '--', for (final rsFile in rustFiles) rsFile]);
 
   // Get ready to handle received signals in Dart.
   var dartReceiveScript = '';


### PR DESCRIPTION
## Changes

resolves #500 

### Using `rustfmt` directly
I had to use `rustfmt` directly because `cargo fmt` relies on additional metadata found in Cargo.toml files. This is error prone because `rinf message` uses absolute paths (👍🏼) but doesn't ensure the working path is the root or subdirectory of a cargo workspace.