### PR TITLE
Call `store_dart_post_cobject` in Rust to avoid symbol conflicts bewteen Flutter packages

### DIFF
--- a/flutter_package/example/android/.gitignore
+++ b/flutter_package/example/android/.gitignore
@@ -5,6 +5,7 @@ gradle-wrapper.jar
 /gradlew.bat
 /local.properties
 GeneratedPluginRegistrant.java
+.cxx/
 
 # Remember to never publicly share your keystore.
 # See https://flutter.dev/to/reference-keystore

--- a/flutter_package/lib/src/interface_os.dart
+++ b/flutter_package/lib/src/interface_os.dart
@@ -15,10 +15,6 @@ void setCompiledLibPathReal(String path) {
 Future<void> prepareInterfaceReal(
   AssignRustSignal assignRustSignal,
 ) async {
-  /// This should be called once at startup
-  /// to enable `allo_isolate` to send data from the Rust side.
-  rustLibrary.storeDartPostCObject(NativeApi.postCObject);
-
   // Prepare ports for communication over isolates.
   final rustSignalPort = ReceivePort();
 
@@ -47,7 +43,11 @@ Future<void> prepareInterfaceReal(
   });
 
   // Make Rust prepare its isolate to send data to Dart.
-  rustLibrary.prepareIsolate(rustSignalPort.sendPort.nativePort);
+  // This is handled by `allo_isolate`.
+  rustLibrary.prepareIsolate(
+    NativeApi.postCObject,
+    rustSignalPort.sendPort.nativePort,
+  );
 }
 
 void startRustLogicReal() {


### PR DESCRIPTION
## Changes

Fixes #521, which was discussed in #520.

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_package --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
