### PR TITLE
Organize unsafe statements

### DIFF
--- a/rust_crate/src/interface_os.rs
+++ b/rust_crate/src/interface_os.rs
@@ -12,13 +12,11 @@ use std::thread;
 static DART_ISOLATE: Mutex<Option<Isolate>> = Mutex::new(None);
 
 #[no_mangle]
-pub extern "C" fn prepare_isolate_extern(
+pub unsafe extern "C" fn prepare_isolate_extern(
     store_post_object: DartPostCObjectFnType,
     port: i64,
 ) {
-    unsafe {
-        store_dart_post_cobject(store_post_object);
-    }
+    store_dart_post_cobject(store_post_object);
     let dart_isolate = Isolate::new(port);
     let mut guard = match DART_ISOLATE.lock() {
         Ok(inner) => inner,

--- a/rust_crate/src/macros.rs
+++ b/rust_crate/src/macros.rs
@@ -33,9 +33,8 @@ macro_rules! write_interface {
             binary_size: usize,
         ) {
             use std::slice::from_raw_parts;
-            let message_bytes =
-                unsafe { from_raw_parts(message_pointer, message_size) };
-            let binary = unsafe { from_raw_parts(binary_pointer, binary_size) };
+            let message_bytes = from_raw_parts(message_pointer, message_size);
+            let binary = from_raw_parts(binary_pointer, binary_size);
             let result =
                 messages::assign_dart_signal(message_id, message_bytes, binary);
             if let Err(error) = result {


### PR DESCRIPTION
## Changes

For clarity, this PR organizes unsafe statements. With this change, there are exactly 2 `unsafe` keywords getting left in the codebase.

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_package --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
