### PR TITLE
Simply borrow Rust signal instance when sending it to Dart

### DIFF
--- a/rust_crate/src/signal_trait.rs
+++ b/rust_crate/src/signal_trait.rs
@@ -32,7 +32,7 @@ pub trait DartSignal<T> {
 pub trait RustSignalBinary {
   /// Sends a signal to Dart with separate binary data.
   /// Passing data from Dart to Rust is a zero-copy operation.
-  fn send_signal_to_dart(self, binary: Vec<u8>);
+  fn send_signal_to_dart(&self, binary: Vec<u8>);
 }
 
 /// Defines the methods that a type capable of
@@ -40,7 +40,7 @@ pub trait RustSignalBinary {
 pub trait RustSignal {
   /// Sends a signal to Dart.
   /// Passing data from Dart to Rust is a zero-copy operation.
-  fn send_signal_to_dart(self);
+  fn send_signal_to_dart(&self);
 }
 
 /// Ensures that all inner structs and enums

--- a/rust_crate_proc/src/lib.rs
+++ b/rust_crate_proc/src/lib.rs
@@ -211,7 +211,7 @@ fn derive_rust_signal_real(
   let expanded = if include_binary {
     quote! {
       impl rinf::RustSignalBinary for #name #where_clause {
-        fn send_signal_to_dart(self, binary: Vec<u8>) {
+        fn send_signal_to_dart(&self, binary: Vec<u8>) {
           use rinf::{AppError, debug_print, send_rust_signal, serialize};
           let type_name = #name_lit;
           let message_result: Result<Vec<u8>, AppError> =
@@ -234,7 +234,7 @@ fn derive_rust_signal_real(
   } else {
     quote! {
       impl rinf::RustSignal for #name #where_clause {
-        fn send_signal_to_dart(self) {
+        fn send_signal_to_dart(&self) {
           use rinf::{AppError, debug_print, send_rust_signal, serialize};
           let type_name = #name_lit;
           let message_result: Result<Vec<u8>, AppError> =


### PR DESCRIPTION
## Changes

There was a minor difference in the function signature of `send_signal_to_dart`, when compared to Rinf version 7. This PR sets the first parameter as `&self`, not `self`, like before.

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_package --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
