### PR TITLE
Improve upgrading section in the docs

### DIFF
--- a/documentation/source/upgrading.md
+++ b/documentation/source/upgrading.md
@@ -51,7 +51,15 @@ rinf server
 
 The way signal messages are used remains unchanged, but their declaration has become much cleaner. Now, we define Rust structs and annotate them with signal trait attributes. Protobuf is no longer used.
 
-Replace the Rinf CLI tool with the new one.
+First, Rinf now requires Rust 1.85 with the 2024 edition. Run the following commands to update:
+
+```{code-block} shell
+:caption: CLI
+rustup update
+rustc --version
+```
+
+Replace the Rinf CLI tool with the new one:
 
 ```{code-block} shell
 :caption: CLI
@@ -59,7 +67,7 @@ cargo uninstall rinf
 cargo install rinf_cli
 ```
 
-Modify your dependencies.
+Modify your dependencies:
 
 ```{code-block} yaml
 :caption: pubspec.yaml (Before)
@@ -95,7 +103,7 @@ rinf = "8.0.0"
 serde = "1.0.202"
 ```
 
-Move all Protobuf messages into the `hub` crate. Placing them inside `native/hub/src/signals/mod.rs` can be a good starting point, though any location within the `hub` crate is acceptable.
+Move all Protobuf messages into the `hub` crate. Placing them inside `native/hub/src/signals/mod.rs` can be a good starting point, though any location within the `hub` crate is acceptable:
 
 ```{code-block} proto
 :caption: Protobuf (Before)
@@ -118,7 +126,7 @@ struct MessageA {}
 struct MessageB {}
 ```
 
-To generate the corresponding Dart code, use `rinf gen` instead of `rinf message`.
+To generate the corresponding Dart code, use `rinf gen` instead of `rinf message`:
 
 ```{code-block} shell
 :caption: CLI
@@ -137,7 +145,7 @@ import 'package:my_app/messages/all.dart';
 import 'package:my_app/src/bindings/bindings.dart';
 ```
 
-The methods of signal structs are the same, but they have now become trait methods. You should explicitly import the traits to ensure the methods still work.
+The methods of signal structs are the same, but they have now become trait methods. You should explicitly import the traits to ensure the methods still work:
 
 ```{code-block} rust
 :caption: Rust (Before)
@@ -151,14 +159,6 @@ use rinf::{DartSignal, RustSignal};
 
 SomeMessage {}.send_signal_to_dart();
 let receiver = SomeMessage::get_dart_signal_receiver();
-```
-
-Also, Rinf now requires Rust 1.85 with the 2024 edition:
-
-```{code-block} shell
-:caption: CLI
-rustup update
-rustc --version
 ```
 
 Finally, verify that your Rinf configurations in `pubspec.yaml` conform to the new format, if present. Don't forget to update the `.gitignore` and `README.md` files as well!

--- a/documentation/source/upgrading.md
+++ b/documentation/source/upgrading.md
@@ -126,7 +126,7 @@ struct MessageA {}
 struct MessageB {}
 ```
 
-To generate the corresponding Dart code, use `rinf gen` instead of `rinf message`:
+To generate the corresponding Dart code, use `rinf gen` instead of `rinf message`. After the new Dart code is generated in `lib/src/bindings`, you might need to manually remove the `lib/messages` and `native/hub/src/messages` directories:
 
 ```{code-block} shell
 :caption: CLI

--- a/documentation/source/upgrading.md
+++ b/documentation/source/upgrading.md
@@ -49,7 +49,7 @@ rinf server
 
 ## Migrating from 7 to 8
 
-The way signal messages are used remains unchanged, but their declaration has become much cleaner. Now, we define the structs in Rust and annotate them with signal trait attributes. Protobuf is no longer used.
+The way signal messages are used remains unchanged, but their declaration has become much cleaner. Now, we define Rust structs and annotate them with signal trait attributes. Protobuf is no longer used.
 
 Replace the Rinf CLI tool with the new one.
 
@@ -57,6 +57,42 @@ Replace the Rinf CLI tool with the new one.
 :caption: CLI
 cargo uninstall rinf
 cargo install rinf_cli
+```
+
+Modify your dependencies.
+
+```{code-block} yaml
+:caption: pubspec.yaml (Before)
+dependencies:
+  # ...
+  rinf: ^7.0.0
+  protobuf: ^3.1.0
+  fixnum: ^1.1.0
+```
+
+```{code-block} yaml
+:caption: pubspec.yaml (After)
+dependencies:
+  # ...
+  rinf: ^8.0.0
+  tuple: ^2.0.2
+  meta: ^1.16.0
+```
+
+```{code-block} toml
+:caption: native/hub/Cargo.toml (Before)
+[dependencies]
+# ...
+rinf = "7.0.0"
+prost = "0.12.6"
+```
+
+```{code-block} toml
+:caption: native/hub/Cargo.toml (After)
+[dependencies]
+# ...
+rinf = "8.0.0"
+serde = "1.0.202"
 ```
 
 Move all Protobuf messages into the `hub` crate. Placing them inside `native/hub/src/signals/mod.rs` can be a good starting point, though any location within the `hub` crate is acceptable.
@@ -81,14 +117,6 @@ struct MessageA {}
 #[derive(Serialize, RustSignal)]
 struct MessageB {}
 ```
-
-There are 5 signal attributes, as follows:
-
-- `DartSignal`
-- `DartSignalBinary`
-- `RustSignal`
-- `RustSignalBinary`
-- `SignalPiece`
 
 To generate the corresponding Dart code, use `rinf gen` instead of `rinf message`.
 
@@ -133,7 +161,7 @@ rustup update
 rustc --version
 ```
 
-Finally, verify that your Rinf configurations in `pubspec.yaml` conform to the new format, if present.
+Finally, verify that your Rinf configurations in `pubspec.yaml` conform to the new format, if present. Don't forget to update the `.gitignore` and `README.md` files as well!
 
 ```{code-block} shell
 :caption: CLI

--- a/documentation/source/upgrading.md
+++ b/documentation/source/upgrading.md
@@ -112,11 +112,13 @@ message MessageA {}
 
 // [RUST-SIGNAL]
 message MessageB {}
+
+message MessageC {}
 ```
 
 ```{code-block} rust
 :caption: Rust (After)
-use rinf::{DartSignal, RustSignal};
+use rinf::{DartSignal, RustSignal, SignalPiece};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, DartSignal)]
@@ -124,6 +126,9 @@ struct MessageA {}
 
 #[derive(Serialize, RustSignal)]
 struct MessageB {}
+
+#[derive(SignalPiece)] // Add `Serialize` or `Deserialize` as necessary
+struct MessageC {}
 ```
 
 To generate the corresponding Dart code, use `rinf gen` instead of `rinf message`. After the new Dart code is generated in `lib/src/bindings`, you might need to manually remove the `lib/messages` and `native/hub/src/messages` directories:

--- a/rust_crate/src/signal_trait.rs
+++ b/rust_crate/src/signal_trait.rs
@@ -45,7 +45,6 @@ pub trait RustSignal {
 
 /// Ensures that all inner structs and enums
 /// within signal structs and enums are also signals.
-#[doc(hidden)]
 pub trait SignalPiece {}
 
 // Implement the trait for simple primitives.


### PR DESCRIPTION
## Changes

This PR adds a number of details to the upgrading section in the docs for smoother migration from version 7 to 8.

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_package --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
