### PR TITLE
Use two spaces for indentation in readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Below is Rust code with business logic, and following that is Dart code with wid
 
 ```rust
 MyMessage {
-    current_number: 7,
-    other_bool: true,
+  current_number: 7,
+  other_bool: true,
 }
 .send_signal_to_dart();
 ```

--- a/flutter_package/README.md
+++ b/flutter_package/README.md
@@ -33,8 +33,8 @@ Below is Rust code with business logic, and following that is Dart code with wid
 
 ```rust
 MyMessage {
-    current_number: 7,
-    other_bool: true,
+  current_number: 7,
+  other_bool: true,
 }
 .send_signal_to_dart();
 ```

--- a/rust_crate/README.md
+++ b/rust_crate/README.md
@@ -33,8 +33,8 @@ Below is Rust code with business logic, and following that is Dart code with wid
 
 ```rust
 MyMessage {
-    current_number: 7,
-    other_bool: true,
+  current_number: 7,
+  other_bool: true,
 }
 .send_signal_to_dart();
 ```


### PR DESCRIPTION
## Changes

.

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_package --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
