### PR TITLE
Make `DartSignal` a non-generic trait

### DIFF
--- a/rust_crate/src/signal_trait.rs
+++ b/rust_crate/src/signal_trait.rs
@@ -8,23 +8,29 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 /// Defines the methods that a type capable of
 /// receiving Dart signals must implement.
-pub trait DartSignalBinary<T> {
+pub trait DartSignalBinary
+where
+  Self: Sized,
+{
   /// Returns the receiver that listens for signals from Dart.
   ///
   /// If this function is called multiple times,
   /// only the most recent receiver remains active,
   /// and all previous ones become inactive after receiving `None`.
-  fn get_dart_signal_receiver() -> SignalReceiver<DartSignalPack<T>>;
+  fn get_dart_signal_receiver() -> SignalReceiver<DartSignalPack<Self>>;
 }
 
 /// Defines the methods that a type capable of
 /// receiving Dart signals must implement.
-pub trait DartSignal<T> {
+pub trait DartSignal
+where
+  Self: Sized,
+{
   /// Returns the receiver that listens for signals from Dart.
   /// If this function is called multiple times,
   /// only the most recent receiver remains active,
   /// and all previous ones become inactive after receiving `None`.
-  fn get_dart_signal_receiver() -> SignalReceiver<DartSignalPack<T>>;
+  fn get_dart_signal_receiver() -> SignalReceiver<DartSignalPack<Self>>;
 }
 
 /// Defines the methods that a type capable of

--- a/rust_crate_proc/src/lib.rs
+++ b/rust_crate_proc/src/lib.rs
@@ -98,9 +98,9 @@ fn derive_dart_signal_real(
 
   // Implement methods and extern functions.
   let signal_trait = if include_binary {
-    quote! { rinf::DartSignalBinary<#name> }
+    quote! { rinf::DartSignalBinary }
   } else {
-    quote! { rinf::DartSignal<#name> }
+    quote! { rinf::DartSignal }
   };
   let expanded = quote! {
     impl #signal_trait for #name #where_clause {


### PR DESCRIPTION
## Changes

`DartSignal` and `DartSignalBinary` are now non-generic traits. This allows for cleaner and more straightforward signal handling.

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_package --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
