### PR TITLE
Block Dart thread until `finalizeRust` is fully completed

### DIFF
--- a/flutter_package/example/lib/main.dart
+++ b/flutter_package/example/lib/main.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:rinf/rinf.dart';
 import 'src/bindings/bindings.dart';
 
-void main() async {
+Future<void> main() async {
   await initializeRust(assignRustSignal);
   createActors();
   runApp(MyApp());

--- a/flutter_package/example/lib/main.dart
+++ b/flutter_package/example/lib/main.dart
@@ -9,7 +9,7 @@ Future<void> main() async {
   runApp(MyApp());
 }
 
-Future<void> createActors() async {
+void createActors() {
   CreateActors().sendSignalToRust();
 }
 
@@ -68,7 +68,7 @@ class MyHomePage extends StatelessWidget {
     return Scaffold(
       body: Center(child: MyColumn()),
       floatingActionButton: FloatingActionButton(
-        onPressed: () async {
+        onPressed: () {
           // The `sendSignalToRust` method is generated
           // on structs that derive `DartSignal`.
           SampleNumberInput(

--- a/flutter_package/example/test/complex_signal_test.dart
+++ b/flutter_package/example/test/complex_signal_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 import 'package:rinf/rinf.dart';
 import 'package:example_app/src/bindings/bindings.dart';
 
-void main() async {
+Future<void> main() async {
   // Build the dynamic library and load it.
   await Process.run('cargo', ['build'], runInShell: true);
   await initializeRust(assignRustSignal, compiledLibPath: getLibPath());

--- a/flutter_package/lib/rinf.dart
+++ b/flutter_package/lib/rinf.dart
@@ -30,7 +30,7 @@ Future<void> initializeRust(
 }
 
 /// Terminates all Rust tasks by dropping the async runtime.
-/// This function blocks the Dart thread
+/// This function very briefly blocks the Dart thread
 /// until the async runtime in Rust is completely dropped.
 /// It's recommended to call this before closing your Flutter app
 /// to prevent potential resource leaks from Rust.

--- a/flutter_package/lib/rinf.dart
+++ b/flutter_package/lib/rinf.dart
@@ -34,7 +34,7 @@ Future<void> initializeRust(
 /// can prevent potential resource leaks.
 /// Please note that on the web, this function does not have any effect,
 /// as tasks are managed by the JavaScript runtime, not Rust.
-void finalizeRust() async {
+void finalizeRust() {
   stopRustLogicReal();
 }
 
@@ -44,7 +44,7 @@ void sendDartSignal(
   String endpointSymbol,
   Uint8List messageBytes,
   Uint8List binary,
-) async {
+) {
   sendDartSignalReal(
     endpointSymbol,
     messageBytes,

--- a/flutter_package/lib/rinf.dart
+++ b/flutter_package/lib/rinf.dart
@@ -30,10 +30,12 @@ Future<void> initializeRust(
 }
 
 /// Terminates all Rust tasks by dropping the async runtime.
-/// Calling this function before closing the Flutter app
-/// can prevent potential resource leaks.
-/// Please note that on the web, this function does not have any effect,
-/// as tasks are managed by the JavaScript runtime, not Rust.
+/// This function blocks the Dart thread
+/// until the async runtime in Rust is completely dropped.
+/// It's recommended to call this before closing your Flutter app
+/// to prevent potential resource leaks from Rust.
+/// On the web, this function has no effect as tasks are managed by
+/// the JavaScript runtime rather than the Rust async runtime.
 void finalizeRust() {
   stopRustLogicReal();
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 # Python scripts manage code and automate tests.
 # We avoid shell scripts because they are platform-dependent.
+# You can run the automation scripts with
+# `uv run automate [command_type]`.
 
 [dependency-groups]
 dev = ["ruff", "pyright"]

--- a/rust_crate/src/interface_os.rs
+++ b/rust_crate/src/interface_os.rs
@@ -106,6 +106,7 @@ where
 #[unsafe(no_mangle)]
 extern "C" fn rinf_stop_rust_logic_extern() {
   SHUTDOWN_EVENTS.dart_stopped.set();
+  SHUTDOWN_EVENTS.rust_stopped.wait();
 }
 
 pub fn send_rust_signal_real(

--- a/rust_crate/src/shutdown.rs
+++ b/rust_crate/src/shutdown.rs
@@ -92,9 +92,8 @@ impl Event {
   /// this method will return immediately.
   /// Otherwise, it will block until `set` is called by another thread.
   pub fn wait(&self) {
-    let event_blocking =
-      EventBlocking::new(self.inner.clone(), self.condvar.clone());
-    event_blocking.wait();
+    let blocking = EventBlocking::new(self.inner.clone(), self.condvar.clone());
+    blocking.wait();
   }
 }
 
@@ -106,7 +105,7 @@ struct EventInner {
 }
 
 impl EventInner {
-  fn new() -> Self {
+  pub fn new() -> Self {
     EventInner {
       flag: false,
       session: 0,
@@ -125,7 +124,7 @@ struct EventBlocking {
 
 #[cfg(not(target_family = "wasm"))]
 impl EventBlocking {
-  fn new(inner: Arc<Mutex<EventInner>>, condvar: Arc<Condvar>) -> Self {
+  pub fn new(inner: Arc<Mutex<EventInner>>, condvar: Arc<Condvar>) -> Self {
     let guard = inner.lock().recover();
     EventBlocking {
       inner: inner.clone(),

--- a/rust_crate_cli/src/tool/template.rs
+++ b/rust_crate_cli/src/tool/template.rs
@@ -184,9 +184,15 @@ fn update_main_dart(root_dir: &Path) -> Result<(), SetupError> {
       );
     }
     if !content.contains("initializeRust(assignRustSignal)") {
+      // Make sure that the main function is async.
+      content =
+        content.replacen("void main() {", "Future<void> main() async {", 1);
+      content =
+        content.replacen("int main() {", "Future<int> main() async {", 1);
+      // Insert the call to `initializeRust`.
       content = content.replacen(
-        "void main() {",
-        "Future<void> main() async {\
+        "main() async {",
+        "main() async {\
         \n  await initializeRust(assignRustSignal);",
         1,
       );

--- a/rust_crate_cli/src/tool/template.rs
+++ b/rust_crate_cli/src/tool/template.rs
@@ -185,8 +185,8 @@ fn update_main_dart(root_dir: &Path) -> Result<(), SetupError> {
     }
     if !content.contains("initializeRust(assignRustSignal)") {
       content = content.replacen(
-        "main() {",
-        "main() async {\n    await initializeRust(assignRustSignal);",
+        "void main() {",
+        "Future<void> main() async {\n  await initializeRust(assignRustSignal);",
         1,
       );
     }

--- a/rust_crate_cli/src/tool/template.rs
+++ b/rust_crate_cli/src/tool/template.rs
@@ -186,7 +186,8 @@ fn update_main_dart(root_dir: &Path) -> Result<(), SetupError> {
     if !content.contains("initializeRust(assignRustSignal)") {
       content = content.replacen(
         "void main() {",
-        "Future<void> main() async {\n  await initializeRust(assignRustSignal);",
+        "Future<void> main() async {\
+        \n  await initializeRust(assignRustSignal);",
         1,
       );
     }


### PR DESCRIPTION
## Changes

Fixes #591 and the shutdown behavior.

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_package --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
