### PR TITLE
Remove the extra curly brace from `DartSignalBinary`

### DIFF
--- a/rust_crate_cli/src/tool/generate.rs
+++ b/rust_crate_cli/src/tool/generate.rs
@@ -407,12 +407,11 @@ extension {class}DartSignalExt on {class} {{
   /// because Rust cannot own data managed by Dart's garbage collector.
   void sendSignalToRust(Uint8List binary) {{
     final messageBytes = bincodeSerialize();
-      sendDartSignal(
-        'rinf_send_dart_signal_{snake_class}',
-        messageBytes,
-        binary,
-      );
-    }}
+    sendDartSignal(
+      'rinf_send_dart_signal_{snake_class}',
+      messageBytes,
+      binary,
+    );
   }}
 }}
 "#


### PR DESCRIPTION
## Changes

Fixes #601

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_package --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
