### PR TITLE
Respect Serde's skip attribute

### DIFF
--- a/documentation/source/messaging.md
+++ b/documentation/source/messaging.md
@@ -119,3 +119,34 @@ struct Inner {
   my_field: bool,
 }
 ```
+
+## Ignoring fields / variants
+
+To ignore a field or variant, annotate it with `#[serde(skip)]`. This is useful when transferring partially private data because it allows you to specify which data is exposed to Dart. See Serde's documentation on [variant](https://serde.rs/variant-attrs.html) and [field](https://serde.rs/field-attrs.html) attributes for more information on how Serde handles this attribute.
+
+```{code-block} rust
+:caption: Rust
+#[derive(Serialize, RustSignal)]
+struct UpdateMessage {
+  event: String,
+  struct_data: StructData,
+  enum_data: EnumData,
+}
+
+#[derive(Serialize, SignalPiece)]
+struct StructData {
+  my_public_field: bool,
+  #[serde(skip)]
+  my_private_field: bool,
+}
+
+#[derive(Serialize, SignalPiece)]
+enum EnumData {
+  Variant1(i32, #[serde(skip)] i32),
+  Variant2 {
+    my_public_field: bool,
+    #[serde(skip)]
+    my_private_field: bool,
+  },
+}
+```

--- a/flutter_package/example/native/hub/src/signals/complex_types.rs
+++ b/flutter_package/example/native/hub/src/signals/complex_types.rs
@@ -14,8 +14,10 @@ pub enum SerdeData {
   OtherTypes(Box<OtherTypes>),
   UnitVariant,
   NewTypeVariant(String),
-  TupleVariant(u32, u64),
+  TupleVariant(u32, #[serde(skip)] NotSerializable, u64),
   StructVariant {
+    #[serde(skip)]
+    ignored: NotSerializable,
     f0: UnitStruct,
     f1: NewTypeStruct,
     f2: TupleStruct,
@@ -107,3 +109,6 @@ pub enum CStyleEnum {
   D,
   E = 10,
 }
+
+#[derive(Default, PartialEq, Clone)]
+pub struct NotSerializable;

--- a/flutter_package/example/native/hub/src/testing/mod.rs
+++ b/flutter_package/example/native/hub/src/testing/mod.rs
@@ -1,7 +1,7 @@
 use crate::signals::{
-  CStyleEnum, ComplexSignalTestResult, List, NewTypeStruct, OtherTypes,
-  PrimitiveTypes, SerdeData, SimpleList, Struct, Tree, TupleStruct, UnitStruct,
-  UnitTestEnd, UnitTestStart,
+  CStyleEnum, ComplexSignalTestResult, List, NewTypeStruct, NotSerializable,
+  OtherTypes, PrimitiveTypes, SerdeData, SimpleList, Struct, Tree, TupleStruct,
+  UnitStruct, UnitTestEnd, UnitTestStart,
 };
 use rinf::{DartSignal, RustSignal};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -163,9 +163,10 @@ fn get_complex_signals() -> Vec<SerdeData> {
     "test.\u{10348}.\u{00a2}\u{0939}\u{20ac}\u{d55c}..".to_string(),
   );
 
-  let v5 = SerdeData::TupleVariant(3, 6);
+  let v5 = SerdeData::TupleVariant(3, NotSerializable, 6);
 
   let v6 = SerdeData::StructVariant {
+    ignored: NotSerializable,
     f0: UnitStruct,
     f1: NewTypeStruct(1),
     f2: TupleStruct(2, 3),


### PR DESCRIPTION
## Changes

Currently, annotating a variant or field with the `#[serde(skip)]`, `#[serde(skip_serializing)]`, `#[serde(skip_serializing_if = "path")]`, or `#[serde(skip_deserializing)]` attributes results in successful compilation but causes runtime errors. Ignoring some fields or variants can be useful when exposing partially private data from the business logic in Rust to Dart.
This PR adds support for the `#[serde(skip)]` attribute and handles the `#[serde(skip_serializing)]`, `#[serde(skip_serializing_if = "path")]` and `#[serde(skip_deserializing)]` attributes by throwing compile-time errors. It also adds a section to the documentation about ignoring fields or variants and adds a few cases to the tests.
Handling only the `#[serde(skip)]` attribute was a deliberate choice because it enables all the functionality of a skip attribute for this project. Supporting the other attributes quickly leads to implementation complexity and user confusion.

For more information on these attributes, see https://serde.rs/variant-attrs.html and https://serde.rs/field-attrs.html.

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_package --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
