### PR TITLE
Enable getting the latest message from `rustSignalStream`

### DIFF
--- a/documentation/source/messaging.md
+++ b/documentation/source/messaging.md
@@ -63,7 +63,7 @@ final subscription = MyDataOutput.rustSignalStream.listen((signalPack) {
 
 // You can also get the latest value received from the stream.
 // This is useful when building and mounting a new widget.
-RustSignalPack<MyDataOutput>? latestSignal = MyDataOutput.latest;
+RustSignalPack<MyDataOutput>? latestSignal = MyDataOutput.latestRustSignal;
 ```
 
 The `DartSignal` trait generates a signal stream from Dart to Rust. Use the `DartSignalBinary` trait to include binary data without the overhead of serialization.

--- a/documentation/source/messaging.md
+++ b/documentation/source/messaging.md
@@ -44,7 +44,7 @@ MyDataOutput { my_field: true }.send_signal_to_dart();
 StreamBuilder(
   stream: MyDataOutput.rustSignalStream,
   builder: (context, snapshot) {
-    final signalPack = snapshot.data;
+    RustSignalPack<MyDataOutput>? signalPack = snapshot.data;
     if (signalPack == null) {
       // Return an empty widget.
     }
@@ -60,6 +60,10 @@ StreamBuilder(
 final subscription = MyDataOutput.rustSignalStream.listen((signalPack) {
   MyDataOutput message = signalPack.message;
 })
+
+// You can also get the latest value received from the stream.
+// This is useful when building and mounting a new widget.
+RustSignalPack<MyDataOutput>? latestSignal = MyDataOutput.latest;
 ```
 
 The `DartSignal` trait generates a signal stream from Dart to Rust. Use the `DartSignalBinary` trait to include binary data without the overhead of serialization.

--- a/flutter_package/example/native/hub/src/actors/performing.rs
+++ b/flutter_package/example/native/hub/src/actors/performing.rs
@@ -218,8 +218,7 @@ impl PerformingActor {
           }
         }
         format!(
-          "There are {} primes from {} to {}.",
-          prime_count, count_from, count_to,
+          "There are {prime_count} primes from {count_from} to {count_to}.",
         )
       });
       join_handles.push(join_handle);

--- a/rust_crate_cli/src/bin/main.rs
+++ b/rust_crate_cli/src/bin/main.rs
@@ -5,7 +5,7 @@ fn main() -> ExitCode {
   use owo_colors::OwoColorize;
   let result = rinf_cli::run_command();
   if let Err(err) = result {
-    eprintln!("{}", format!("Error: {}", err).red());
+    eprintln!("{}", format!("Error: {err}").red());
     return ExitCode::FAILURE;
   };
   ExitCode::SUCCESS

--- a/rust_crate_cli/src/tool/error.rs
+++ b/rust_crate_cli/src/tool/error.rs
@@ -37,22 +37,22 @@ impl Display for SetupError {
   fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
     match self {
       Self::Io(e) => {
-        write!(f, "Failed to operate on file: {}", e)
+        write!(f, "Failed to operate on file: {e}")
       }
       Self::Yaml(e) => {
-        write!(f, "Failed to parse YAML: {}", e)
+        write!(f, "Failed to parse YAML: {e}")
       }
       Self::Clipboard(e) => {
-        write!(f, "Failed to use clipboard: {}", e)
+        write!(f, "Failed to use clipboard: {e}")
       }
       Self::WatchingFile(e) => {
-        write!(f, "Failed to watch files: {}", e)
+        write!(f, "Failed to watch files: {e}")
       }
       Self::ReflectionModule => {
         write!(f, "Failed to write reflection modules")
       }
       Self::PubConfig(s) => {
-        write!(f, "Invalid `pubspec.yaml` config: {}", s)
+        write!(f, "Invalid `pubspec.yaml` config: {s}")
       }
       Self::BadFilePath(p) => {
         write!(f, "Invalid file path: `{}`", p.display())
@@ -64,10 +64,10 @@ impl Display for SetupError {
         write!(f, "Rust template has already been applied")
       }
       Self::DuplicatedSignal(n) => {
-        write!(f, "Duplicated signals named `{}` were found", n)
+        write!(f, "Duplicated signals named `{n}` were found")
       }
       Self::CodeSyntax(n) => {
-        write!(f, "Invalid syntax in file `{}`", n)
+        write!(f, "Invalid syntax in file `{n}`")
       }
       Self::SubprocessError => {
         write!(f, "A subprocess did not exit successfully")

--- a/rust_crate_cli/src/tool/generate.rs
+++ b/rust_crate_cli/src/tool/generate.rs
@@ -434,7 +434,7 @@ fn generate_class_extension_code(
   extracted_attrs: &BTreeSet<SignalAttribute>,
 ) -> Result<(), SetupError> {
   let snake_class = class.to_snake_case();
-  let class_file = gen_dir.join(GEN_MOD).join(format!("{}.dart", snake_class));
+  let class_file = gen_dir.join(GEN_MOD).join(format!("{snake_class}.dart"));
   let mut code = read_to_string(&class_file)?;
 
   if extracted_attrs.contains(&SignalAttribute::DartSignalBinary) {
@@ -488,7 +488,7 @@ fn generate_class_interface_code(
   extracted_attrs: &BTreeSet<SignalAttribute>,
 ) -> Result<(), SetupError> {
   let snake_class = class.to_snake_case();
-  let class_file = gen_dir.join(GEN_MOD).join(format!("{}.dart", snake_class));
+  let class_file = gen_dir.join(GEN_MOD).join(format!("{snake_class}.dart"));
   let mut code = read_to_string(&class_file)?;
 
   let has_rust_signal = extracted_attrs.contains(&SignalAttribute::RustSignal)
@@ -503,22 +503,21 @@ final _{camel_class}StreamController =
     );
     code.push_str(&new_code);
     code = code.replacen(
-      &format!("class {} {{", class),
+      &format!("class {class} {{"),
       &format!(
-        r#"class {} {{
+        r#"class {class} {{
   /// An async broadcast stream that listens for signals from Rust.
   /// It supports multiple subscriptions.
   /// Make sure to cancel the subscription when it's no longer needed,
   /// such as when a widget is disposed.
   static final rustSignalStream =
-      _{}StreamController.stream.asBroadcastStream();
+      _{camel_class}StreamController.stream.asBroadcastStream();
         
   /// The latest signal value received from Rust.
   /// This is updated every time a new signal is received.
   /// It can be null if no signals have been received yet.
   static RustSignalPack<{class}>? latestRustSignal = null;
-"#,
-        class, camel_class
+"#
       ),
       1,
     );
@@ -533,7 +532,7 @@ fn generate_shared_code(
   signal_attrs: &BTreeMap<String, BTreeSet<SignalAttribute>>,
 ) -> Result<(), SetupError> {
   // Write type aliases.
-  let mut code = format!("part of '{}.dart';\n", GEN_MOD);
+  let mut code = format!("part of '{GEN_MOD}.dart';\n");
 
   // Write signal handler.
   code.push_str(
@@ -581,7 +580,7 @@ fn generate_interface_code(
   }
 
   // Write imports.
-  let top_file = gen_dir.join(GEN_MOD).join(format!("{}.dart", GEN_MOD));
+  let top_file = gen_dir.join(GEN_MOD).join(format!("{GEN_MOD}.dart"));
   let mut top_content = read_to_string(&top_file)?;
   top_content = top_content.replacen(
     "export '../serde/serde.dart';",
@@ -650,8 +649,8 @@ pub fn generate_dart_code(
   // Write the export file.
   let gen_dir_name = gen_dir.clean_file_name()?;
   write(
-    gen_dir.join(format!("{}.dart", gen_dir_name)),
-    format!("export '{}/{}.dart';", GEN_MOD, GEN_MOD),
+    gen_dir.join(format!("{gen_dir_name}.dart")),
+    format!("export '{GEN_MOD}/{GEN_MOD}.dart';"),
   )?;
 
   // Generate Dart interface code for FFI.
@@ -675,13 +674,13 @@ pub fn watch_and_generate_dart_code(
       let event = match event_result {
         Ok(inner) => inner,
         Err(err) => {
-          eprintln!("Watch error: {}", err);
+          eprintln!("Watch error: {err}");
           return;
         }
       };
       let send_result = sender.send(event);
       if let Err(err) = send_result {
-        eprintln!("{}", err);
+        eprintln!("{err}");
       }
     },
     Config::default(),
@@ -704,12 +703,12 @@ pub fn watch_and_generate_dart_code(
           );
           let result = generate_dart_code(root_dir, rinf_config);
           if let Err(err) = result {
-            eprintln!("{}", err);
+            eprintln!("{err}");
           }
         }
       }
       Err(err) => {
-        eprintln!("{}", err);
+        eprintln!("{err}");
         break;
       }
     }
@@ -753,7 +752,7 @@ fn move_directory_contents(
 fn remove_lint_warnings(gen_dir: &Path) -> Result<(), SetupError> {
   write_lint_ignore(&gen_dir.join("serde").join("serde.dart"))?;
   write_lint_ignore(&gen_dir.join("bincode").join("bincode.dart"))?;
-  write_lint_ignore(&gen_dir.join(GEN_MOD).join(format!("{}.dart", GEN_MOD)))?;
+  write_lint_ignore(&gen_dir.join(GEN_MOD).join(format!("{GEN_MOD}.dart")))?;
   Ok(())
 }
 
@@ -761,7 +760,7 @@ fn write_lint_ignore(file_path: &Path) -> Result<(), SetupError> {
   let content = read_to_string(file_path)?;
   write(
     file_path,
-    format!("// ignore_for_file: type=lint, type=warning\n{}", content),
+    format!("// ignore_for_file: type=lint, type=warning\n{content}"),
   )?;
   Ok(())
 }

--- a/rust_crate_cli/src/tool/generate.rs
+++ b/rust_crate_cli/src/tool/generate.rs
@@ -516,7 +516,7 @@ final _{camel_class}StreamController =
   /// The latest signal value received from Rust.
   /// This is updated every time a new signal is received.
   /// It can be null if no signals have been received yet.
-  static RustSignalPack<{class}>? latest = null;
+  static RustSignalPack<{class}>? latestRustSignal = null;
 "#,
         class, camel_class
       ),
@@ -557,7 +557,7 @@ fn generate_shared_code(
       binary,
     );
     _{camel_class}StreamController.add(rustSignal);
-    {class}.latest = rustSignal;
+    {class}.latestRustSignal = rustSignal;
   }},"#
     );
     code.push_str(&new_code);

--- a/rust_crate_cli/src/tool/generate.rs
+++ b/rust_crate_cli/src/tool/generate.rs
@@ -512,6 +512,11 @@ final _{camel_class}StreamController =
   /// such as when a widget is disposed.
   static final rustSignalStream =
       _{}StreamController.stream.asBroadcastStream();
+        
+  /// The latest signal value received from Rust.
+  /// This is updated every time a new signal is received.
+  /// It can be null if no signals have been received yet.
+  static RustSignalPack<{class}>? latest = null;
 "#,
         class, camel_class
       ),
@@ -552,6 +557,7 @@ fn generate_shared_code(
       binary,
     );
     _{camel_class}StreamController.add(rustSignal);
+    {class}.latest = rustSignal;
   }},"#
     );
     code.push_str(&new_code);

--- a/rust_crate_cli/src/tool/server.rs
+++ b/rust_crate_cli/src/tool/server.rs
@@ -9,7 +9,7 @@ pub fn provide_server_command(release: bool) -> Result<(), SetupError> {
     " --web-header=Cross-Origin-Opener-Policy=same-origin",
     " --web-header=Cross-Origin-Embedder-Policy=require-corp",
   );
-  let full_command = format!("{}{}", base_command, release_arg);
+  let full_command = format!("{base_command}{release_arg}");
   clipboard.set_text(full_command)?;
   Ok(())
 }

--- a/rust_crate_proc/src/lib.rs
+++ b/rust_crate_proc/src/lib.rs
@@ -97,10 +97,10 @@ fn derive_dart_signal_real(
   };
 
   // Collect identifiers and names.
-  let channel_type_ident = Ident::new(&format!("{}Channel", name), name.span());
+  let channel_type_ident = Ident::new(&format!("{name}Channel"), name.span());
   let channel_const_ident =
-    Ident::new(&format!("{}_CHANNEL", upper_snake_name), name.span());
-  let extern_fn_name = &format!("rinf_send_dart_signal_{}", snake_name);
+    Ident::new(&format!("{upper_snake_name}_CHANNEL"), name.span());
+  let extern_fn_name = &format!("rinf_send_dart_signal_{snake_name}");
   let extern_fn_ident = Ident::new(extern_fn_name, name.span());
 
   // Implement methods and extern functions.
@@ -561,8 +561,7 @@ fn create_name_error(ast: DeriveInput) -> TokenStream {
   Error::new_spanned(
     ast.ident,
     format!(
-      "The name of a foreign signal cannot start with `{}`",
-      BANNED_LOWER_PREFIX
+      "The name of a foreign signal cannot start with `{BANNED_LOWER_PREFIX}`"
     ),
   )
   .to_compile_error()


### PR DESCRIPTION
## Changes

Related to #623

This PR allows you to access the latest singal value from `rustSignalStream`.

## Before Committing

_Please make sure that you've analyzed and formatted the files._

```
dart analyze flutter_package --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
