### PR TITLE
Check signal name only for signals

### DIFF
--- a/rust_crate_cli/src/tool/generate.rs
+++ b/rust_crate_cli/src/tool/generate.rs
@@ -374,10 +374,10 @@ fn process_items_in_module(
       }
       Item::Struct(s) => {
         let item_name = s.ident.to_string();
-        check_signal_name(&item_name, traced)?;
         let signal_attrs = extract_signal_attributes(&s.attrs)
           .ok_or(SetupError::CodeSyntax(file_name.to_owned()))?;
         if !signal_attrs.is_empty() {
+          check_signal_name(&item_name, traced)?;
           trace_struct(traced, s);
           traced.signal_attrs.insert(item_name.clone(), signal_attrs);
           let doc_comment = extract_doc_comment(&s.attrs);
@@ -387,10 +387,10 @@ fn process_items_in_module(
       }
       Item::Enum(e) => {
         let item_name = e.ident.to_string();
-        check_signal_name(&item_name, traced)?;
         let signal_attrs = extract_signal_attributes(&e.attrs)
           .ok_or(SetupError::CodeSyntax(file_name.to_owned()))?;
         if !signal_attrs.is_empty() {
+          check_signal_name(&item_name, traced)?;
           trace_enum(traced, e);
           traced.signal_attrs.insert(item_name.clone(), signal_attrs);
           let doc_comment = extract_doc_comment(&e.attrs);


### PR DESCRIPTION
## Summary

Fixes a bug in `rinf gen` (present in v8.7.0) where name conflicts between signal and non-signal structs/enums in different modules cause generation to abort, depending on module processing order.

## Problem

In Rinf v8.7.0, the `rinf gen` command fails when a signal struct or enum shares the same name as a non-signal struct or enum in another module. This occurs only if the signal's module is processed before the non-signal's module. The processing order appears to be filesystem-dependent (e.g., alphabetical or OS-specific directory listing), leading to inconsistent behavior across environments.

For example:

- Signal: `SomeRequest` in `module1.rs` (marked as a signal).
- Non-signal: `SomeRequest` in `module2.rs` (not a signal).

If `module1` is processed first, `rinf gen` aborts with:

```
Error: Duplicated signals named `SomeRequest` were found
```

If `module2` is processed first, generation succeeds without issues.

## Fix

- Updated the signal validation logic in `rust_crate_cli/src/tool/generate.rs` to perform uniqueness checks only after confirming that a struct or enum is indeed a signal (previously, checks occurred before this confirmation).
- This change avoids incorrectly flagging non-signal types as duplicates, ensuring consistent generation regardless of module processing order.