### PR TITLE
Prevent long-line truncation in debug_print

### DIFF
--- a/flutter_package/lib/rinf.dart
+++ b/flutter_package/lib/rinf.dart
@@ -3,6 +3,7 @@ library;
 
 import 'dart:typed_data';
 import 'dart:convert';
+import 'package:flutter/foundation.dart' show debugPrint;
 import 'src/structure.dart';
 import 'src/interface.dart';
 
@@ -21,7 +22,7 @@ Future<void> initializeRust(
   // Add the print delegation endpoint.
   assignRustSignal['RinfOut'] = (messageBytes, binary) {
     final rustReport = utf8.decode(binary);
-    print(rustReport);
+    debugPrint(rustReport, wrapWidth: 1024);
   };
 
   // Prepare the interface with Rust.


### PR DESCRIPTION
Long debug messages from Rust are often truncated in consoles because the current `print(rustReport)` call does not wrap long single lines.
Switching to `debugPrint(rustReport, wrapWidth: 1024)` prevents this truncation by enabling controlled wrapping when lines exceed the specified width.
`debugPrint` is Flutter's recommended mechanism for debug output: it is throttled, respects platform constraints, and produces more reliable results across environments.
The change has negligible overhead, affects only debug logging, and significantly improves developer experience when inspecting detailed Rust output.