### PR TITLE
fix(ohos build cargokit): update build directory resolution and error reporting

### DIFF
--- a/flutter_package/cargokit/hvigor/src/plugin/cargokit-hvigor-plugin.ts
+++ b/flutter_package/cargokit/hvigor/src/plugin/cargokit-hvigor-plugin.ts
@@ -68,9 +68,17 @@ function registerCargokitTask(
         "libs",
         targetName,
       );
-      const buildDir = resolve(dir, "build");
-
       const rootNodeDirPath = node.getParentNode()?.nodeDir.filePath;
+      // <project>/build/rinf/build/build_tool
+      // Avoid cannot operate on packages inside the cache.
+      const buildDir = resolve(
+        rootNodeDirPath,
+        "..",
+        "build",
+        "rinf",
+        "build",
+        "build_tool",
+      );
 
       if (!rootNodeDirPath) {
         throw new Error("rootNodeDirPath is required");
@@ -86,17 +94,18 @@ function registerCargokitTask(
         env: {
           ...process.env,
           CARGOKIT_ROOT_PROJECT_DIR: rootNodeDirPath,
-          CARGOKIT_TOOL_TEMP_DIR: `${buildDir}/build_tool`,
+          CARGOKIT_TOOL_TEMP_DIR: buildDir,
           CARGOKIT_TARGET_PLATFORMS: PLATFORMS.join(","),
           CARGOKIT_MANIFEST_DIR: cargokitManifestPath,
           CARGOKIT_CONFIGURATION: "release",
-          CARGOKIT_TARGET_TEMP_DIR: `${buildDir}/cargokit`,
+          CARGOKIT_TARGET_TEMP_DIR: `${resolve(dir, "build", "cargokit")}`,
           CARGOKIT_OUTPUT_DIR: outputDir,
         },
       });
 
       if (result.status !== 0) {
-        throw new Error(`cargokitTask failed with status ${result.status}`);
+        throw new Error(`cargokitTask failed with status ${result.status}
+stderr: ${result.stderr ? `${result.stderr.toString()}` : ""}`);
       }
     },
     dependencies: [`${targetName}@ProcessLibs`],


### PR DESCRIPTION
- Adjust the build directory path to point to the rinf build tool directory
to avoid operating on packages inside the cache.
- Update the environment variables for temporary directories and improve error
messages by including stderr when the cargokit task fails.