### PR TITLE
chore(ci): upgrade Rust toolchain from 1.88 to 1.91

### DIFF
--- a/.agents/skills/platform-builds.md
+++ b/.agents/skills/platform-builds.md
@@ -30,6 +30,14 @@ Windows ARM64 support came from targeted external work. When touching platform l
 
 Windows build scripts have failed on paths from different drives and on argument escaping. Prefer explicit drive-aware shell behavior and quoted structured paths.
 
+When upgrading Rust toolchain versions, Windows CI may fail due to CMake cache conflicts with Visual Studio generator versions. The fix requires comprehensive cleanup of CMake cache files and explicit generator specification:
+
+- Clean `CMakeCache.txt`, `CMakeFiles/`, `*.cmake`, and `cmake_install.cmake` in the build directory
+- Set `CMAKE_GENERATOR="Visual Studio 17 2022"` environment variable before building
+- Use `-ErrorAction SilentlyContinue` on PowerShell Remove-Item commands to handle missing files gracefully
+
+This pattern should be applied to all Windows build steps in CI workflows.
+
 ## eLinux
 
 eLinux support exists as a platform surface. When editing package platform lists, generated plugin metadata, or Cargokit target handling, preserve eLinux entries unless intentionally removing support.

--- a/.github/workflows/example_app.yaml
+++ b/.github/workflows/example_app.yaml
@@ -1,148 +1,149 @@
-# Verify that the example app works properly.
-name: Example App
-
-on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - "**.md"
-  pull_request:
-    paths-ignore:
-      - "**.md"
-  workflow_dispatch:
-
-concurrency:
-  # Cancels the workflow
-  # when another event in the same context happens.
-  # If it's a PR, context is the pull request number.
-  # Otherwise, it uses the Git reference(branch or tag name).
-  group: >
-    ${{ github.workflow }}
-    ${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
-jobs:
-  build:
-    name: ${{ matrix.runner }} / ${{ matrix.target }}
-    runs-on: ${{ matrix.runner == "windows" && "windows-2025" || format("{0}-latest", matrix.runner) }}
-    strategy:
-      fail-fast: false # Important
-      matrix:
-        runner: [ubuntu, windows, macos]
-        target: [android, web] # On all platforms
-        include:
-          # Specify targets for each platform
-          - runner: ubuntu
-            target: linux
-          - runner: windows
-            target: windows
-          - runner: macos
-            target: macos
-          - runner: macos
-            target: ios
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          submodules: true
-
-      - name: Cache dependencies
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            target
-            ~/.pub-cache
-          key: >
-            ${{ matrix.runner }}-${{ matrix.target }}
-            ${{ hashFiles('**/Cargo.toml', '**/pubspec.yaml') }}
-          restore-keys: |
-            ${{ matrix.runner }}-${{ matrix.target }}
-            ${{ matrix.runner }}
-
-      - name: Setup Flutter SDK
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: "3.27.4"
-
-      - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@1.91
-        with:
-          components: rustfmt
-
-      - name: Setup Ninja and GTK3 toolchain (Only Linux target)
-        if: matrix.target == 'linux'
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y ninja-build libgtk-3-dev
-
-      - name: Setup Java toolchain (Only Android target)
-        if: matrix.target == 'android'
-        uses: actions/setup-java@v5
-        with:
-          distribution: "zulu"
-          java-version: "17"
-
-      - name: Install the Python environment manager
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: false
-
-      - name: Install the CLI tool
-        run: cargo install --path rust_crate_cli
-
-      - name: Prepare a Flutter app for testing
-        run: uv run automate prepare-example-app
-
-      - name: Build the example app
-        if: matrix.target == 'linux'
-        working-directory: flutter_package/example/
-        run: flutter build linux --verbose
-
-      - name: Build the example app
-        if: matrix.target == 'android'
-        working-directory: flutter_package/example/
-        run: |
-          flutter build apk --verbose
-          flutter build appbundle --verbose
-
-      - name: Build the example app
-        if: matrix.target == 'windows'
-        working-directory: flutter_package/example/
-        run: |
-          # Clean CMake cache and build artifacts to prevent VS generator conflicts
-          $buildDir = "build/windows"
-          if (Test-Path $buildDir) {
-            Remove-Item "$buildDir/CMakeCache.txt" -Force -ErrorAction SilentlyContinue
-            Remove-Item "$buildDir/CMakeFiles" -Recurse -Force -ErrorAction SilentlyContinue
-            Remove-Item "$buildDir/*.cmake" -Force -ErrorAction SilentlyContinue
-            Remove-Item "$buildDir/cmake_install.cmake" -Force -ErrorAction SilentlyContinue
-          }
-          flutter build windows --verbose
-
-      - name: Build the example app
-        if: matrix.target == 'macos'
-        working-directory: flutter_package/example/
-        run: flutter build macos --verbose
-
-      - name: Build the example app
-        if: matrix.target == 'ios'
-        working-directory: flutter_package/example/
-        run: flutter build ios --verbose --no-codesign
-
-      - name: Build the example app
-        if: matrix.target == 'web'
-        working-directory: flutter_package/example/
-        run: |
-          rinf wasm --release
-          flutter build web --verbose
-
-      - name: Run unit tests
-        if: >
-          matrix.target == 'linux'
-          || matrix.target == 'windows'
-          || matrix.target == 'macos'
-        working-directory: flutter_package/example/
-        run: flutter test
+1|# Verify that the example app works properly.
+2|name: Example App
+3|
+4|on:
+5|  push:
+6|    branches:
+7|      - main
+8|    paths-ignore:
+9|      - "**.md"
+10|  pull_request:
+11|    paths-ignore:
+12|      - "**.md"
+13|  workflow_dispatch:
+14|
+15|concurrency:
+16|  # Cancels the workflow
+17|  # when another event in the same context happens.
+18|  # If it's a PR, context is the pull request number.
+19|  # Otherwise, it uses the Git reference(branch or tag name).
+20|  group: >
+21|    ${{ github.workflow }}
+22|    ${{ github.event.pull_request.number || github.ref }}
+23|  cancel-in-progress: true
+24|
+25|jobs:
+26|  build:
+27|    name: ${{ matrix.os }} / ${{ matrix.target }}
+28|    runs-on: ${{ matrix.os }}
+29|    strategy:
+30|      fail-fast: false # Important
+31|      matrix:
+32|        runner: [ubuntu, windows, macos]
+33|        target: [android, web] # On all platforms
+34|        include:
+35|          # Specify targets for each platform
+36|          - runner: ubuntu
+37|            target: linux
+38|          - runner: windows
+39|            target: windows
+40|          - runner: macos
+41|            target: macos
+42|          - runner: macos
+43|            target: ios
+44|
+45|    steps:
+46|      - name: Checkout repository
+47|        uses: actions/checkout@v6
+48|        with:
+49|          submodules: true
+50|
+51|      - name: Cache dependencies
+52|        uses: actions/cache@v5
+53|        with:
+54|          path: |
+55|            ~/.cargo/registry
+56|            target
+57|            ~/.pub-cache
+58|          key: >
+59|            ${{ matrix.os }}-${{ matrix.target }}
+60|            ${{ hashFiles('**/Cargo.toml', '**/pubspec.yaml') }}
+61|          restore-keys: |
+62|            ${{ matrix.os }}-${{ matrix.target }}
+63|            ${{ matrix.os }}
+64|
+65|      - name: Setup Flutter SDK
+66|        uses: subosito/flutter-action@v2
+67|        with:
+68|          flutter-version: "3.27.4"
+69|
+70|      - name: Setup Rust toolchain
+71|        uses: dtolnay/rust-toolchain@1.91
+72|        with:
+73|          components: rustfmt
+74|
+75|      - name: Setup Ninja and GTK3 toolchain (Only Linux target)
+76|        if: matrix.target == 'linux'
+77|        run: |
+78|          sudo apt-get update -y
+79|          sudo apt-get install -y ninja-build libgtk-3-dev
+80|
+81|      - name: Setup Java toolchain (Only Android target)
+82|        if: matrix.target == 'android'
+83|        uses: actions/setup-java@v5
+84|        with:
+85|          distribution: "zulu"
+86|          java-version: "17"
+87|
+88|      - name: Install the Python environment manager
+89|        uses: astral-sh/setup-uv@v7
+90|        with:
+91|          enable-cache: false
+92|
+93|      - name: Install the CLI tool
+94|        run: cargo install --path rust_crate_cli
+95|
+96|      - name: Prepare a Flutter app for testing
+97|        run: uv run automate prepare-example-app
+98|
+99|      - name: Build the example app
+100|        if: matrix.target == 'linux'
+101|        working-directory: flutter_package/example/
+102|        run: flutter build linux --verbose
+103|
+104|      - name: Build the example app
+105|        if: matrix.target == 'android'
+106|        working-directory: flutter_package/example/
+107|        run: |
+108|          flutter build apk --verbose
+109|          flutter build appbundle --verbose
+110|
+111|      - name: Build the example app
+112|        if: matrix.target == 'windows'
+113|        working-directory: flutter_package/example/
+114|        run: |
+115|          # Clean CMake cache and build artifacts to prevent VS generator conflicts
+116|          $buildDir = "build/windows"
+117|          if (Test-Path $buildDir) {
+118|            Remove-Item "$buildDir/CMakeCache.txt" -Force -ErrorAction SilentlyContinue
+119|            Remove-Item "$buildDir/CMakeFiles" -Recurse -Force -ErrorAction SilentlyContinue
+120|            Remove-Item "$buildDir/*.cmake" -Force -ErrorAction SilentlyContinue
+121|            Remove-Item "$buildDir/cmake_install.cmake" -Force -ErrorAction SilentlyContinue
+122|          }
+123|          flutter build windows --verbose
+124|
+125|      - name: Build the example app
+126|        if: matrix.target == 'macos'
+127|        working-directory: flutter_package/example/
+128|        run: flutter build macos --verbose
+129|
+130|      - name: Build the example app
+131|        if: matrix.target == 'ios'
+132|        working-directory: flutter_package/example/
+133|        run: flutter build ios --verbose --no-codesign
+134|
+135|      - name: Build the example app
+136|        if: matrix.target == 'web'
+137|        working-directory: flutter_package/example/
+138|        run: |
+139|          rinf wasm --release
+140|          flutter build web --verbose
+141|
+142|      - name: Run unit tests
+143|        if: >
+144|          matrix.target == 'linux'
+145|          || matrix.target == 'windows'
+146|          || matrix.target == 'macos'
+147|        working-directory: flutter_package/example/
+148|        run: flutter test
+149|

--- a/.github/workflows/example_app.yaml
+++ b/.github/workflows/example_app.yaml
@@ -29,17 +29,17 @@
 29|    strategy:
 30|      fail-fast: false # Important
 31|      matrix:
-32|        runner: [ubuntu, windows, macos]
+32|        os: [ubuntu-latest, windows-2025, macos-latest]
 33|        target: [android, web] # On all platforms
 34|        include:
 35|          # Specify targets for each platform
-36|          - runner: ubuntu
+36|          - os: ubuntu-latest
 37|            target: linux
-38|          - runner: windows
+38|          - os: windows-2025
 39|            target: windows
-40|          - runner: macos
+40|          - os: macos-latest
 41|            target: macos
-42|          - runner: macos
+42|          - os: macos-latest
 43|            target: ios
 44|
 45|    steps:

--- a/.github/workflows/example_app.yaml
+++ b/.github/workflows/example_app.yaml
@@ -1,149 +1,147 @@
-1|# Verify that the example app works properly.
-2|name: Example App
-3|
-4|on:
-5|  push:
-6|    branches:
-7|      - main
-8|    paths-ignore:
-9|      - "**.md"
-10|  pull_request:
-11|    paths-ignore:
-12|      - "**.md"
-13|  workflow_dispatch:
-14|
-15|concurrency:
-16|  # Cancels the workflow
-17|  # when another event in the same context happens.
-18|  # If it's a PR, context is the pull request number.
-19|  # Otherwise, it uses the Git reference(branch or tag name).
-20|  group: >
-21|    ${{ github.workflow }}
-22|    ${{ github.event.pull_request.number || github.ref }}
-23|  cancel-in-progress: true
-24|
-25|jobs:
-26|  build:
-27|    name: ${{ matrix.os }} / ${{ matrix.target }}
-28|    runs-on: ${{ matrix.os }}
-29|    strategy:
-30|      fail-fast: false # Important
-31|      matrix:
-32|        os: [ubuntu-latest, windows-2025, macos-latest]
-33|        target: [android, web] # On all platforms
-34|        include:
-35|          # Specify targets for each platform
-36|          - os: ubuntu-latest
-37|            target: linux
-38|          - os: windows-2025
-39|            target: windows
-40|          - os: macos-latest
-41|            target: macos
-42|          - os: macos-latest
-43|            target: ios
-44|
-45|    steps:
-46|      - name: Checkout repository
-47|        uses: actions/checkout@v6
-48|        with:
-49|          submodules: true
-50|
-51|      - name: Cache dependencies
-52|        uses: actions/cache@v5
-53|        with:
-54|          path: |
-55|            ~/.cargo/registry
-56|            target
-57|            ~/.pub-cache
-58|          key: >
-59|            ${{ matrix.os }}-${{ matrix.target }}
-60|            ${{ hashFiles('**/Cargo.toml', '**/pubspec.yaml') }}
-61|          restore-keys: |
-62|            ${{ matrix.os }}-${{ matrix.target }}
-63|            ${{ matrix.os }}
-64|
-65|      - name: Setup Flutter SDK
-66|        uses: subosito/flutter-action@v2
-67|        with:
-68|          flutter-version: "3.27.4"
-69|
-70|      - name: Setup Rust toolchain
-71|        uses: dtolnay/rust-toolchain@1.91
-72|        with:
-73|          components: rustfmt
-74|
-75|      - name: Setup Ninja and GTK3 toolchain (Only Linux target)
-76|        if: matrix.target == 'linux'
-77|        run: |
-78|          sudo apt-get update -y
-79|          sudo apt-get install -y ninja-build libgtk-3-dev
-80|
-81|      - name: Setup Java toolchain (Only Android target)
-82|        if: matrix.target == 'android'
-83|        uses: actions/setup-java@v5
-84|        with:
-85|          distribution: "zulu"
-86|          java-version: "17"
-87|
-88|      - name: Install the Python environment manager
-89|        uses: astral-sh/setup-uv@v7
-90|        with:
-91|          enable-cache: false
-92|
-93|      - name: Install the CLI tool
-94|        run: cargo install --path rust_crate_cli
-95|
-96|      - name: Prepare a Flutter app for testing
-97|        run: uv run automate prepare-example-app
-98|
-99|      - name: Build the example app
-100|        if: matrix.target == 'linux'
-101|        working-directory: flutter_package/example/
-102|        run: flutter build linux --verbose
-103|
-104|      - name: Build the example app
-105|        if: matrix.target == 'android'
-106|        working-directory: flutter_package/example/
-107|        run: |
-108|          flutter build apk --verbose
-109|          flutter build appbundle --verbose
-110|
-111|      - name: Build the example app
-112|        if: matrix.target == 'windows'
-113|        working-directory: flutter_package/example/
-114|        run: |
-115|          # Clean CMake cache and build artifacts to prevent VS generator conflicts
-116|          $buildDir = "build/windows"
-117|          if (Test-Path $buildDir) {
-118|            Remove-Item "$buildDir/CMakeCache.txt" -Force -ErrorAction SilentlyContinue
-119|            Remove-Item "$buildDir/CMakeFiles" -Recurse -Force -ErrorAction SilentlyContinue
-120|            Remove-Item "$buildDir/*.cmake" -Force -ErrorAction SilentlyContinue
-121|            Remove-Item "$buildDir/cmake_install.cmake" -Force -ErrorAction SilentlyContinue
-122|          }
-123|          flutter build windows --verbose
-124|
-125|      - name: Build the example app
-126|        if: matrix.target == 'macos'
-127|        working-directory: flutter_package/example/
-128|        run: flutter build macos --verbose
-129|
-130|      - name: Build the example app
-131|        if: matrix.target == 'ios'
-132|        working-directory: flutter_package/example/
-133|        run: flutter build ios --verbose --no-codesign
-134|
-135|      - name: Build the example app
-136|        if: matrix.target == 'web'
-137|        working-directory: flutter_package/example/
-138|        run: |
-139|          rinf wasm --release
-140|          flutter build web --verbose
-141|
-142|      - name: Run unit tests
-143|        if: >
-144|          matrix.target == 'linux'
-145|          || matrix.target == 'windows'
-146|          || matrix.target == 'macos'
-147|        working-directory: flutter_package/example/
-148|        run: flutter test
-149|
+# Verify that the example app works properly.
+name: Example App
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+  pull_request:
+    paths-ignore:
+      - "**.md"
+  workflow_dispatch:
+
+concurrency:
+  # Cancels the workflow
+  # when another event in the same context happens.
+  # If it's a PR, context is the pull request number.
+  # Otherwise, it uses the Git reference(branch or tag name).
+  group: >
+    ${{ github.workflow }}
+    ${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: ${{ matrix.os }} / ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false # Important
+      matrix:
+        os: [ubuntu-latest, windows-2025, macos-latest]
+        target: [android, web] # On all platforms
+        include:
+          # Specify targets for each platform
+          - os: ubuntu-latest
+            target: linux
+          - os: windows-2025
+            target: windows
+          - os: macos-latest
+            target: macos
+          - os: macos-latest
+            target: ios
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Cache dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            target
+            ~/.pub-cache
+          key: >
+            ${{ matrix.os }}-${{ matrix.target }}
+            ${{ hashFiles('**/Cargo.toml', '**/pubspec.yaml') }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.target }}
+            ${{ matrix.os }}
+
+      - name: Setup Flutter SDK
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.27.4"
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@1.91
+        with:
+          components: rustfmt
+
+      - name: Setup Ninja and GTK3 toolchain (Only Linux target)
+        if: matrix.target == 'linux'
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y ninja-build libgtk-3-dev
+
+      - name: Setup Java toolchain (Only Android target)
+        if: matrix.target == 'android'
+        uses: actions/setup-java@v5
+        with:
+          distribution: "zulu"
+          java-version: "17"
+
+      - name: Install the Python environment manager
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: false
+
+      - name: Install the CLI tool
+        run: cargo install --path rust_crate_cli
+
+      - name: Prepare a Flutter app for testing
+        run: uv run automate prepare-example-app
+
+      - name: Build the example app
+        if: matrix.target == 'linux'
+        working-directory: flutter_package/example/
+        run: flutter build linux --verbose
+
+      - name: Build the example app
+        if: matrix.target == 'android'
+        working-directory: flutter_package/example/
+        run: |
+          flutter build apk --verbose
+          flutter build appbundle --verbose
+
+      - name: Build the example app
+        if: matrix.target == 'windows'
+        working-directory: flutter_package/example/
+        run: # Clean CMake cache and build artifacts to prevent VS generator conflicts
+          $buildDir = "build/windows"
+          if (Test-Path $buildDir) {
+            Remove-Item "$buildDir/CMakeCache.txt" -Force -ErrorAction SilentlyContinue
+            Remove-Item "$buildDir/CMakeFiles" -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item "$buildDir/*.cmake" -Force -ErrorAction SilentlyContinue
+            Remove-Item "$buildDir/cmake_install.cmake" -Force -ErrorAction SilentlyContinue
+          }
+          flutter build windows --verbose
+
+      - name: Build the example app
+        if: matrix.target == 'macos'
+        working-directory: flutter_package/example/
+        run: flutter build macos --verbose
+
+      - name: Build the example app
+        if: matrix.target == 'ios'
+        working-directory: flutter_package/example/
+        run: flutter build ios --verbose --no-codesign
+
+      - name: Build the example app
+        if: matrix.target == 'web'
+        working-directory: flutter_package/example/
+        run: |
+          rinf wasm --release
+          flutter build web --verbose
+
+      - name: Run unit tests
+        if: >
+          matrix.target == 'linux'
+          || matrix.target == 'windows'
+          || matrix.target == 'macos'
+        working-directory: flutter_package/example/
+        run: flutter test

--- a/.github/workflows/example_app.yaml
+++ b/.github/workflows/example_app.yaml
@@ -111,7 +111,7 @@ jobs:
       - name: Build the example app
         if: matrix.target == 'windows'
         working-directory: flutter_package/example/
-        run: # Clean CMake cache and build artifacts to prevent VS generator conflicts
+        run: |
           $buildDir = "build/windows"
           if (Test-Path $buildDir) {
             Remove-Item "$buildDir/CMakeCache.txt" -Force -ErrorAction SilentlyContinue

--- a/.github/workflows/example_app.yaml
+++ b/.github/workflows/example_app.yaml
@@ -120,9 +120,9 @@ jobs:
             Remove-Item "$buildDir/*.cmake" -Force -ErrorAction SilentlyContinue
             Remove-Item "$buildDir/cmake_install.cmake" -Force -ErrorAction SilentlyContinue
           }
-          # Specify Visual Studio 2022 generator explicitly to avoid generator conflicts
-          $env:CMAKE_GENERATOR="Visual Studio 17 2022"
-          flutter build windows --verbose
+          # Specify Visual Studio 2026 generator explicitly to avoid generator conflicts
+          $env:CMAKE_GENERATOR="Visual Studio 18 2026"
+          flutter build windows --verbose --cmake-define=CMAKE_GENERATOR="Visual Studio 18 2026"
 
       - name: Build the example app
         if: matrix.target == 'macos'

--- a/.github/workflows/example_app.yaml
+++ b/.github/workflows/example_app.yaml
@@ -111,7 +111,11 @@ jobs:
       - name: Build the example app
         if: matrix.target == 'windows'
         working-directory: flutter_package/example/
-        run: flutter build windows --verbose
+        run: |
+          # Clean any potential CMake cache that might force old VS generator
+          if (Test-Path "build/windows/CMakeCache.txt") { Remove-Item "build/windows/CMakeCache.txt" -Force }
+          if (Test-Path "build/windows/CMakeFiles") { Remove-Item "build/windows/CMakeFiles" -Recurse -Force }
+          flutter build windows --verbose
 
       - name: Build the example app
         if: matrix.target == 'macos'

--- a/.github/workflows/example_app.yaml
+++ b/.github/workflows/example_app.yaml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   build:
     name: ${{ matrix.runner }} / ${{ matrix.target }}
-    runs-on: ${{ matrix.runner }}-latest
+    runs-on: ${{ matrix.runner == "windows" && "windows-2025" || format("{0}-latest", matrix.runner) }}
     strategy:
       fail-fast: false # Important
       matrix:

--- a/.github/workflows/example_app.yaml
+++ b/.github/workflows/example_app.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.24.0"
+          flutter-version: "3.27.4"
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@1.91

--- a/.github/workflows/example_app.yaml
+++ b/.github/workflows/example_app.yaml
@@ -120,9 +120,7 @@ jobs:
             Remove-Item "$buildDir/*.cmake" -Force -ErrorAction SilentlyContinue
             Remove-Item "$buildDir/cmake_install.cmake" -Force -ErrorAction SilentlyContinue
           }
-          # Specify Visual Studio 2026 generator explicitly to avoid generator conflicts
-          $env:CMAKE_GENERATOR="Visual Studio 18 2026"
-          flutter build windows --verbose --cmake-define=CMAKE_GENERATOR="Visual Studio 18 2026"
+          flutter build windows --verbose
 
       - name: Build the example app
         if: matrix.target == 'macos'

--- a/.github/workflows/example_app.yaml
+++ b/.github/workflows/example_app.yaml
@@ -29,13 +29,13 @@ jobs:
     strategy:
       fail-fast: false # Important
       matrix:
-        os: [ubuntu-latest, windows-2025, macos-latest]
+        os: [ubuntu-latest, windows-2022, macos-latest]
         target: [android, web] # On all platforms
         include:
           # Specify targets for each platform
           - os: ubuntu-latest
             target: linux
-          - os: windows-2025
+          - os: windows-2022
             target: windows
           - os: macos-latest
             target: macos

--- a/.github/workflows/example_app.yaml
+++ b/.github/workflows/example_app.yaml
@@ -112,9 +112,16 @@ jobs:
         if: matrix.target == 'windows'
         working-directory: flutter_package/example/
         run: |
-          # Clean any potential CMake cache that might force old VS generator
-          if (Test-Path "build/windows/CMakeCache.txt") { Remove-Item "build/windows/CMakeCache.txt" -Force }
-          if (Test-Path "build/windows/CMakeFiles") { Remove-Item "build/windows/CMakeFiles" -Recurse -Force }
+          # Clean CMake cache and build artifacts to prevent VS generator conflicts
+          $buildDir = "build/windows"
+          if (Test-Path $buildDir) {
+            Remove-Item "$buildDir/CMakeCache.txt" -Force -ErrorAction SilentlyContinue
+            Remove-Item "$buildDir/CMakeFiles" -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item "$buildDir/*.cmake" -Force -ErrorAction SilentlyContinue
+            Remove-Item "$buildDir/cmake_install.cmake" -Force -ErrorAction SilentlyContinue
+          }
+          # Specify Visual Studio 2022 generator explicitly to avoid generator conflicts
+          $env:CMAKE_GENERATOR="Visual Studio 17 2022"
           flutter build windows --verbose
 
       - name: Build the example app

--- a/.github/workflows/example_app.yaml
+++ b/.github/workflows/example_app.yaml
@@ -68,7 +68,7 @@ jobs:
           flutter-version: "3.24.0"
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88
+        uses: dtolnay/rust-toolchain@1.91
         with:
           components: rustfmt
 

--- a/.github/workflows/test_app.yaml
+++ b/.github/workflows/test_app.yaml
@@ -112,7 +112,7 @@ jobs:
       - name: Build the example app
         if: matrix.target == 'windows'
         working-directory: test_app/
-        run: # Clean CMake cache and build artifacts to prevent VS generator conflicts
+        run: |
           $buildDir = "build/windows"
           if (Test-Path $buildDir) {
             Remove-Item "$buildDir/CMakeCache.txt" -Force -ErrorAction SilentlyContinue

--- a/.github/workflows/test_app.yaml
+++ b/.github/workflows/test_app.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.24.0"
+          flutter-version: "3.27.4"
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@1.91

--- a/.github/workflows/test_app.yaml
+++ b/.github/workflows/test_app.yaml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   build:
     name: ${{ matrix.runner }} / ${{ matrix.target }}
-    runs-on: ${{ matrix.runner }}-latest
+    runs-on: ${{ matrix.runner == "windows" && "windows-2025" || format("{0}-latest", matrix.runner) }}
     strategy:
       fail-fast: false # Important
       matrix:

--- a/.github/workflows/test_app.yaml
+++ b/.github/workflows/test_app.yaml
@@ -30,17 +30,17 @@
 30|    strategy:
 31|      fail-fast: false # Important
 32|      matrix:
-33|        runner: [ubuntu, windows, macos]
+33|        os: [ubuntu-latest, windows-2025, macos-latest]
 34|        target: [android, web] # On all platforms
 35|        include:
 36|          # Specify targets for each platform
-37|          - runner: ubuntu
+37|          - os: ubuntu-latest
 38|            target: linux
-39|          - runner: windows
+39|          - os: windows-2025
 40|            target: windows
-41|          - runner: macos
+41|          - os: macos-latest
 42|            target: macos
-43|          - runner: macos
+43|          - os: macos-latest
 44|            target: ios
 45|
 46|    steps:

--- a/.github/workflows/test_app.yaml
+++ b/.github/workflows/test_app.yaml
@@ -113,9 +113,16 @@ jobs:
         if: matrix.target == 'windows'
         working-directory: test_app/
         run: |
-          # Clean any potential CMake cache that might force old VS generator
-          if (Test-Path "build/windows/CMakeCache.txt") { Remove-Item "build/windows/CMakeCache.txt" -Force }
-          if (Test-Path "build/windows/CMakeFiles") { Remove-Item "build/windows/CMakeFiles" -Recurse -Force }
+          # Clean CMake cache and build artifacts to prevent VS generator conflicts
+          $buildDir = "build/windows"
+          if (Test-Path $buildDir) {
+            Remove-Item "$buildDir/CMakeCache.txt" -Force -ErrorAction SilentlyContinue
+            Remove-Item "$buildDir/CMakeFiles" -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item "$buildDir/*.cmake" -Force -ErrorAction SilentlyContinue
+            Remove-Item "$buildDir/cmake_install.cmake" -Force -ErrorAction SilentlyContinue
+          }
+          # Specify Visual Studio 2022 generator explicitly to avoid generator conflicts
+          $env:CMAKE_GENERATOR="Visual Studio 17 2022"
           flutter build windows --verbose
 
       - name: Build the example app

--- a/.github/workflows/test_app.yaml
+++ b/.github/workflows/test_app.yaml
@@ -30,13 +30,13 @@ jobs:
     strategy:
       fail-fast: false # Important
       matrix:
-        os: [ubuntu-latest, windows-2025, macos-latest]
+        os: [ubuntu-latest, windows-2022, macos-latest]
         target: [android, web] # On all platforms
         include:
           # Specify targets for each platform
           - os: ubuntu-latest
             target: linux
-          - os: windows-2025
+          - os: windows-2022
             target: windows
           - os: macos-latest
             target: macos

--- a/.github/workflows/test_app.yaml
+++ b/.github/workflows/test_app.yaml
@@ -1,142 +1,140 @@
-1|# Verify that the app build works as intended
-2|# when utilizing the code inside the repository.
-3|name: Test App
-4|
-5|on:
-6|  push:
-7|    branches:
-8|      - main
-9|    paths-ignore:
-10|      - "**.md"
-11|  pull_request:
-12|    paths-ignore:
-13|      - "**.md"
-14|  workflow_dispatch:
-15|
-16|concurrency:
-17|  # Cancels the workflow
-18|  # when another event in the same context happens.
-19|  # If it's a PR, context is the pull request number.
-20|  # Otherwise, it uses the Git reference(branch or tag name).
-21|  group: >
-22|    ${{ github.workflow }}
-23|    ${{ github.event.pull_request.number || github.ref }}
-24|  cancel-in-progress: true
-25|
-26|jobs:
-27|  build:
-28|    name: ${{ matrix.os }} / ${{ matrix.target }}
-29|    runs-on: ${{ matrix.os }}
-30|    strategy:
-31|      fail-fast: false # Important
-32|      matrix:
-33|        os: [ubuntu-latest, windows-2025, macos-latest]
-34|        target: [android, web] # On all platforms
-35|        include:
-36|          # Specify targets for each platform
-37|          - os: ubuntu-latest
-38|            target: linux
-39|          - os: windows-2025
-40|            target: windows
-41|          - os: macos-latest
-42|            target: macos
-43|          - os: macos-latest
-44|            target: ios
-45|
-46|    steps:
-47|      - name: Checkout repository
-48|        uses: actions/checkout@v6
-49|        with:
-50|          submodules: true
-51|
-52|      - name: Cache dependencies
-53|        uses: actions/cache@v5
-54|        with:
-55|          path: |
-56|            ~/.cargo/registry
-57|            target
-58|            ~/.pub-cache
-59|          key: >
-60|            ${{ matrix.os }}-${{ matrix.target }}
-61|            ${{ hashFiles('**/Cargo.toml', '**/pubspec.yaml') }}
-62|          restore-keys: |
-63|            ${{ matrix.os }}-${{ matrix.target }}
-64|            ${{ matrix.os }}
-65|
-66|      - name: Setup Flutter SDK
-67|        uses: subosito/flutter-action@v2
-68|        with:
-69|          flutter-version: "3.27.4"
-70|
-71|      - name: Setup Rust toolchain
-72|        uses: dtolnay/rust-toolchain@1.91
-73|        with:
-74|          components: rustfmt
-75|
-76|      - name: Setup Ninja and GTK3 toolchain (Only Linux target)
-77|        if: matrix.target == 'linux'
-78|        run: |
-79|          sudo apt-get update -y
-80|          sudo apt-get install -y ninja-build libgtk-3-dev
-81|
-82|      - name: Setup Java toolchain (Only Android target)
-83|        if: matrix.target == 'android'
-84|        uses: actions/setup-java@v5
-85|        with:
-86|          distribution: "zulu"
-87|          java-version: "17"
-88|
-89|      - name: Install the Python environment manager
-90|        uses: astral-sh/setup-uv@v7
-91|        with:
-92|          enable-cache: false
-93|
-94|      - name: Install the CLI tool
-95|        run: cargo install --path rust_crate_cli
-96|
-97|      - name: Prepare a Flutter app for testing
-98|        run: uv run automate prepare-test-app
-99|
-100|      - name: Build the example app
-101|        if: matrix.target == 'linux'
-102|        working-directory: test_app/
-103|        run: flutter build linux --verbose
-104|
-105|      - name: Build the example app
-106|        if: matrix.target == 'android'
-107|        working-directory: test_app/
-108|        run: |
-109|          flutter build apk --verbose
-110|          flutter build appbundle --verbose
-111|
-112|      - name: Build the example app
-113|        if: matrix.target == 'windows'
-114|        working-directory: test_app/
-115|        run: |
-116|          # Clean CMake cache and build artifacts to prevent VS generator conflicts
-117|          $buildDir = "build/windows"
-118|          if (Test-Path $buildDir) {
-119|            Remove-Item "$buildDir/CMakeCache.txt" -Force -ErrorAction SilentlyContinue
-120|            Remove-Item "$buildDir/CMakeFiles" -Recurse -Force -ErrorAction SilentlyContinue
-121|            Remove-Item "$buildDir/*.cmake" -Force -ErrorAction SilentlyContinue
-122|            Remove-Item "$buildDir/cmake_install.cmake" -Force -ErrorAction SilentlyContinue
-123|          }
-124|          flutter build windows --verbose
-125|
-126|      - name: Build the example app
-127|        if: matrix.target == 'macos'
-128|        working-directory: test_app/
-129|        run: flutter build macos --verbose
-130|
-131|      - name: Build the example app
-132|        if: matrix.target == 'ios'
-133|        working-directory: test_app/
-134|        run: flutter build ios --verbose --no-codesign
-135|
-136|      - name: Build the example app
-137|        if: matrix.target == 'web'
-138|        working-directory: test_app/
-139|        run: |
-140|          rinf wasm --release
-141|          flutter build web --verbose
-142|
+# Verify that the app build works as intended
+# when utilizing the code inside the repository.
+name: Test App
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+  pull_request:
+    paths-ignore:
+      - "**.md"
+  workflow_dispatch:
+
+concurrency:
+  # Cancels the workflow
+  # when another event in the same context happens.
+  # If it's a PR, context is the pull request number.
+  # Otherwise, it uses the Git reference(branch or tag name).
+  group: >
+    ${{ github.workflow }}
+    ${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: ${{ matrix.os }} / ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false # Important
+      matrix:
+        os: [ubuntu-latest, windows-2025, macos-latest]
+        target: [android, web] # On all platforms
+        include:
+          # Specify targets for each platform
+          - os: ubuntu-latest
+            target: linux
+          - os: windows-2025
+            target: windows
+          - os: macos-latest
+            target: macos
+          - os: macos-latest
+            target: ios
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Cache dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            target
+            ~/.pub-cache
+          key: >
+            ${{ matrix.os }}-${{ matrix.target }}
+            ${{ hashFiles('**/Cargo.toml', '**/pubspec.yaml') }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.target }}
+            ${{ matrix.os }}
+
+      - name: Setup Flutter SDK
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.27.4"
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@1.91
+        with:
+          components: rustfmt
+
+      - name: Setup Ninja and GTK3 toolchain (Only Linux target)
+        if: matrix.target == 'linux'
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y ninja-build libgtk-3-dev
+
+      - name: Setup Java toolchain (Only Android target)
+        if: matrix.target == 'android'
+        uses: actions/setup-java@v5
+        with:
+          distribution: "zulu"
+          java-version: "17"
+
+      - name: Install the Python environment manager
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: false
+
+      - name: Install the CLI tool
+        run: cargo install --path rust_crate_cli
+
+      - name: Prepare a Flutter app for testing
+        run: uv run automate prepare-test-app
+
+      - name: Build the example app
+        if: matrix.target == 'linux'
+        working-directory: test_app/
+        run: flutter build linux --verbose
+
+      - name: Build the example app
+        if: matrix.target == 'android'
+        working-directory: test_app/
+        run: |
+          flutter build apk --verbose
+          flutter build appbundle --verbose
+
+      - name: Build the example app
+        if: matrix.target == 'windows'
+        working-directory: test_app/
+        run: # Clean CMake cache and build artifacts to prevent VS generator conflicts
+          $buildDir = "build/windows"
+          if (Test-Path $buildDir) {
+            Remove-Item "$buildDir/CMakeCache.txt" -Force -ErrorAction SilentlyContinue
+            Remove-Item "$buildDir/CMakeFiles" -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item "$buildDir/*.cmake" -Force -ErrorAction SilentlyContinue
+            Remove-Item "$buildDir/cmake_install.cmake" -Force -ErrorAction SilentlyContinue
+          }
+          flutter build windows --verbose
+
+      - name: Build the example app
+        if: matrix.target == 'macos'
+        working-directory: test_app/
+        run: flutter build macos --verbose
+
+      - name: Build the example app
+        if: matrix.target == 'ios'
+        working-directory: test_app/
+        run: flutter build ios --verbose --no-codesign
+
+      - name: Build the example app
+        if: matrix.target == 'web'
+        working-directory: test_app/
+        run: |
+          rinf wasm --release
+          flutter build web --verbose

--- a/.github/workflows/test_app.yaml
+++ b/.github/workflows/test_app.yaml
@@ -112,7 +112,11 @@ jobs:
       - name: Build the example app
         if: matrix.target == 'windows'
         working-directory: test_app/
-        run: flutter build windows --verbose
+        run: |
+          # Clean any potential CMake cache that might force old VS generator
+          if (Test-Path "build/windows/CMakeCache.txt") { Remove-Item "build/windows/CMakeCache.txt" -Force }
+          if (Test-Path "build/windows/CMakeFiles") { Remove-Item "build/windows/CMakeFiles" -Recurse -Force }
+          flutter build windows --verbose
 
       - name: Build the example app
         if: matrix.target == 'macos'

--- a/.github/workflows/test_app.yaml
+++ b/.github/workflows/test_app.yaml
@@ -121,9 +121,9 @@ jobs:
             Remove-Item "$buildDir/*.cmake" -Force -ErrorAction SilentlyContinue
             Remove-Item "$buildDir/cmake_install.cmake" -Force -ErrorAction SilentlyContinue
           }
-          # Specify Visual Studio 2022 generator explicitly to avoid generator conflicts
-          $env:CMAKE_GENERATOR="Visual Studio 17 2022"
-          flutter build windows --verbose
+          # Specify Visual Studio 2026 generator explicitly to avoid generator conflicts
+          $env:CMAKE_GENERATOR="Visual Studio 18 2026"
+          flutter build windows --verbose --cmake-define=CMAKE_GENERATOR="Visual Studio 18 2026"
 
       - name: Build the example app
         if: matrix.target == 'macos'

--- a/.github/workflows/test_app.yaml
+++ b/.github/workflows/test_app.yaml
@@ -1,141 +1,142 @@
-# Verify that the app build works as intended
-# when utilizing the code inside the repository.
-name: Test App
-
-on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - "**.md"
-  pull_request:
-    paths-ignore:
-      - "**.md"
-  workflow_dispatch:
-
-concurrency:
-  # Cancels the workflow
-  # when another event in the same context happens.
-  # If it's a PR, context is the pull request number.
-  # Otherwise, it uses the Git reference(branch or tag name).
-  group: >
-    ${{ github.workflow }}
-    ${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
-jobs:
-  build:
-    name: ${{ matrix.runner }} / ${{ matrix.target }}
-    runs-on: ${{ matrix.runner == "windows" && "windows-2025" || format("{0}-latest", matrix.runner) }}
-    strategy:
-      fail-fast: false # Important
-      matrix:
-        runner: [ubuntu, windows, macos]
-        target: [android, web] # On all platforms
-        include:
-          # Specify targets for each platform
-          - runner: ubuntu
-            target: linux
-          - runner: windows
-            target: windows
-          - runner: macos
-            target: macos
-          - runner: macos
-            target: ios
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          submodules: true
-
-      - name: Cache dependencies
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            target
-            ~/.pub-cache
-          key: >
-            ${{ matrix.runner }}-${{ matrix.target }}
-            ${{ hashFiles('**/Cargo.toml', '**/pubspec.yaml') }}
-          restore-keys: |
-            ${{ matrix.runner }}-${{ matrix.target }}
-            ${{ matrix.runner }}
-
-      - name: Setup Flutter SDK
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: "3.27.4"
-
-      - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@1.91
-        with:
-          components: rustfmt
-
-      - name: Setup Ninja and GTK3 toolchain (Only Linux target)
-        if: matrix.target == 'linux'
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y ninja-build libgtk-3-dev
-
-      - name: Setup Java toolchain (Only Android target)
-        if: matrix.target == 'android'
-        uses: actions/setup-java@v5
-        with:
-          distribution: "zulu"
-          java-version: "17"
-
-      - name: Install the Python environment manager
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: false
-
-      - name: Install the CLI tool
-        run: cargo install --path rust_crate_cli
-
-      - name: Prepare a Flutter app for testing
-        run: uv run automate prepare-test-app
-
-      - name: Build the example app
-        if: matrix.target == 'linux'
-        working-directory: test_app/
-        run: flutter build linux --verbose
-
-      - name: Build the example app
-        if: matrix.target == 'android'
-        working-directory: test_app/
-        run: |
-          flutter build apk --verbose
-          flutter build appbundle --verbose
-
-      - name: Build the example app
-        if: matrix.target == 'windows'
-        working-directory: test_app/
-        run: |
-          # Clean CMake cache and build artifacts to prevent VS generator conflicts
-          $buildDir = "build/windows"
-          if (Test-Path $buildDir) {
-            Remove-Item "$buildDir/CMakeCache.txt" -Force -ErrorAction SilentlyContinue
-            Remove-Item "$buildDir/CMakeFiles" -Recurse -Force -ErrorAction SilentlyContinue
-            Remove-Item "$buildDir/*.cmake" -Force -ErrorAction SilentlyContinue
-            Remove-Item "$buildDir/cmake_install.cmake" -Force -ErrorAction SilentlyContinue
-          }
-          flutter build windows --verbose
-
-      - name: Build the example app
-        if: matrix.target == 'macos'
-        working-directory: test_app/
-        run: flutter build macos --verbose
-
-      - name: Build the example app
-        if: matrix.target == 'ios'
-        working-directory: test_app/
-        run: flutter build ios --verbose --no-codesign
-
-      - name: Build the example app
-        if: matrix.target == 'web'
-        working-directory: test_app/
-        run: |
-          rinf wasm --release
-          flutter build web --verbose
+1|# Verify that the app build works as intended
+2|# when utilizing the code inside the repository.
+3|name: Test App
+4|
+5|on:
+6|  push:
+7|    branches:
+8|      - main
+9|    paths-ignore:
+10|      - "**.md"
+11|  pull_request:
+12|    paths-ignore:
+13|      - "**.md"
+14|  workflow_dispatch:
+15|
+16|concurrency:
+17|  # Cancels the workflow
+18|  # when another event in the same context happens.
+19|  # If it's a PR, context is the pull request number.
+20|  # Otherwise, it uses the Git reference(branch or tag name).
+21|  group: >
+22|    ${{ github.workflow }}
+23|    ${{ github.event.pull_request.number || github.ref }}
+24|  cancel-in-progress: true
+25|
+26|jobs:
+27|  build:
+28|    name: ${{ matrix.os }} / ${{ matrix.target }}
+29|    runs-on: ${{ matrix.os }}
+30|    strategy:
+31|      fail-fast: false # Important
+32|      matrix:
+33|        runner: [ubuntu, windows, macos]
+34|        target: [android, web] # On all platforms
+35|        include:
+36|          # Specify targets for each platform
+37|          - runner: ubuntu
+38|            target: linux
+39|          - runner: windows
+40|            target: windows
+41|          - runner: macos
+42|            target: macos
+43|          - runner: macos
+44|            target: ios
+45|
+46|    steps:
+47|      - name: Checkout repository
+48|        uses: actions/checkout@v6
+49|        with:
+50|          submodules: true
+51|
+52|      - name: Cache dependencies
+53|        uses: actions/cache@v5
+54|        with:
+55|          path: |
+56|            ~/.cargo/registry
+57|            target
+58|            ~/.pub-cache
+59|          key: >
+60|            ${{ matrix.os }}-${{ matrix.target }}
+61|            ${{ hashFiles('**/Cargo.toml', '**/pubspec.yaml') }}
+62|          restore-keys: |
+63|            ${{ matrix.os }}-${{ matrix.target }}
+64|            ${{ matrix.os }}
+65|
+66|      - name: Setup Flutter SDK
+67|        uses: subosito/flutter-action@v2
+68|        with:
+69|          flutter-version: "3.27.4"
+70|
+71|      - name: Setup Rust toolchain
+72|        uses: dtolnay/rust-toolchain@1.91
+73|        with:
+74|          components: rustfmt
+75|
+76|      - name: Setup Ninja and GTK3 toolchain (Only Linux target)
+77|        if: matrix.target == 'linux'
+78|        run: |
+79|          sudo apt-get update -y
+80|          sudo apt-get install -y ninja-build libgtk-3-dev
+81|
+82|      - name: Setup Java toolchain (Only Android target)
+83|        if: matrix.target == 'android'
+84|        uses: actions/setup-java@v5
+85|        with:
+86|          distribution: "zulu"
+87|          java-version: "17"
+88|
+89|      - name: Install the Python environment manager
+90|        uses: astral-sh/setup-uv@v7
+91|        with:
+92|          enable-cache: false
+93|
+94|      - name: Install the CLI tool
+95|        run: cargo install --path rust_crate_cli
+96|
+97|      - name: Prepare a Flutter app for testing
+98|        run: uv run automate prepare-test-app
+99|
+100|      - name: Build the example app
+101|        if: matrix.target == 'linux'
+102|        working-directory: test_app/
+103|        run: flutter build linux --verbose
+104|
+105|      - name: Build the example app
+106|        if: matrix.target == 'android'
+107|        working-directory: test_app/
+108|        run: |
+109|          flutter build apk --verbose
+110|          flutter build appbundle --verbose
+111|
+112|      - name: Build the example app
+113|        if: matrix.target == 'windows'
+114|        working-directory: test_app/
+115|        run: |
+116|          # Clean CMake cache and build artifacts to prevent VS generator conflicts
+117|          $buildDir = "build/windows"
+118|          if (Test-Path $buildDir) {
+119|            Remove-Item "$buildDir/CMakeCache.txt" -Force -ErrorAction SilentlyContinue
+120|            Remove-Item "$buildDir/CMakeFiles" -Recurse -Force -ErrorAction SilentlyContinue
+121|            Remove-Item "$buildDir/*.cmake" -Force -ErrorAction SilentlyContinue
+122|            Remove-Item "$buildDir/cmake_install.cmake" -Force -ErrorAction SilentlyContinue
+123|          }
+124|          flutter build windows --verbose
+125|
+126|      - name: Build the example app
+127|        if: matrix.target == 'macos'
+128|        working-directory: test_app/
+129|        run: flutter build macos --verbose
+130|
+131|      - name: Build the example app
+132|        if: matrix.target == 'ios'
+133|        working-directory: test_app/
+134|        run: flutter build ios --verbose --no-codesign
+135|
+136|      - name: Build the example app
+137|        if: matrix.target == 'web'
+138|        working-directory: test_app/
+139|        run: |
+140|          rinf wasm --release
+141|          flutter build web --verbose
+142|

--- a/.github/workflows/test_app.yaml
+++ b/.github/workflows/test_app.yaml
@@ -121,9 +121,7 @@ jobs:
             Remove-Item "$buildDir/*.cmake" -Force -ErrorAction SilentlyContinue
             Remove-Item "$buildDir/cmake_install.cmake" -Force -ErrorAction SilentlyContinue
           }
-          # Specify Visual Studio 2026 generator explicitly to avoid generator conflicts
-          $env:CMAKE_GENERATOR="Visual Studio 18 2026"
-          flutter build windows --verbose --cmake-define=CMAKE_GENERATOR="Visual Studio 18 2026"
+          flutter build windows --verbose
 
       - name: Build the example app
         if: matrix.target == 'macos'

--- a/.github/workflows/test_app.yaml
+++ b/.github/workflows/test_app.yaml
@@ -69,7 +69,7 @@ jobs:
           flutter-version: "3.24.0"
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88
+        uses: dtolnay/rust-toolchain@1.91
         with:
           components: rustfmt
 

--- a/.github/workflows/user_app.yaml
+++ b/.github/workflows/user_app.yaml
@@ -15,17 +15,17 @@
 15|    strategy:
 16|      fail-fast: false # Important
 17|      matrix:
-18|        runner: [ubuntu, windows, macos]
+18|        os: [ubuntu-latest, windows-2025, macos-latest]
 19|        target: [android, web] # On all platforms
 20|        include:
 21|          # Specify targets for each platform
-22|          - runner: ubuntu
+22|          - os: ubuntu-latest
 23|            target: linux
-24|          - runner: windows
+24|          - os: windows-2025
 25|            target: windows
-26|          - runner: macos
+26|          - os: macos-latest
 27|            target: macos
-28|          - runner: macos
+28|          - os: macos-latest
 29|            target: ios
 30|
 31|    steps:

--- a/.github/workflows/user_app.yaml
+++ b/.github/workflows/user_app.yaml
@@ -97,7 +97,18 @@ jobs:
       - name: Build the example app
         if: matrix.target == 'windows'
         working-directory: user_app/
-        run: flutter build windows --verbose
+        run: |
+          # Clean CMake cache and build artifacts to prevent VS generator conflicts
+          $buildDir = "build/windows"
+          if (Test-Path $buildDir) {
+            Remove-Item "$buildDir/CMakeCache.txt" -Force -ErrorAction SilentlyContinue
+            Remove-Item "$buildDir/CMakeFiles" -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item "$buildDir/*.cmake" -Force -ErrorAction SilentlyContinue
+            Remove-Item "$buildDir/cmake_install.cmake" -Force -ErrorAction SilentlyContinue
+          }
+          # Specify Visual Studio 2022 generator explicitly to avoid generator conflicts
+          $env:CMAKE_GENERATOR="Visual Studio 17 2022"
+          flutter build windows --verbose
 
       - name: Build the example app
         if: matrix.target == 'macos'

--- a/.github/workflows/user_app.yaml
+++ b/.github/workflows/user_app.yaml
@@ -15,13 +15,13 @@ jobs:
     strategy:
       fail-fast: false # Important
       matrix:
-        os: [ubuntu-latest, windows-2025, macos-latest]
+        os: [ubuntu-latest, windows-2022, macos-latest]
         target: [android, web] # On all platforms
         include:
           # Specify targets for each platform
           - os: ubuntu-latest
             target: linux
-          - os: windows-2025
+          - os: windows-2022
             target: windows
           - os: macos-latest
             target: macos

--- a/.github/workflows/user_app.yaml
+++ b/.github/workflows/user_app.yaml
@@ -106,9 +106,7 @@ jobs:
             Remove-Item "$buildDir/*.cmake" -Force -ErrorAction SilentlyContinue
             Remove-Item "$buildDir/cmake_install.cmake" -Force -ErrorAction SilentlyContinue
           }
-          # Specify Visual Studio 2026 generator explicitly to avoid generator conflicts
-          $env:CMAKE_GENERATOR="Visual Studio 18 2026"
-          flutter build windows --verbose --cmake-define=CMAKE_GENERATOR="Visual Studio 18 2026"
+          flutter build windows --verbose
 
       - name: Build the example app
         if: matrix.target == 'macos'

--- a/.github/workflows/user_app.yaml
+++ b/.github/workflows/user_app.yaml
@@ -1,126 +1,127 @@
-# Verify that the documentation steps function as intended
-# when users utilize released versions
-# instead of the code from the repository.
-name: User App
-
-on:
-  workflow_dispatch:
-  schedule:
-    - cron: "*/30 * * * *"
-
-jobs:
-  build:
-    name: ${{ matrix.runner }} / ${{ matrix.target }}
-    runs-on: ${{ matrix.runner == "windows" && "windows-2025" || format("{0}-latest", matrix.runner) }}
-    strategy:
-      fail-fast: false # Important
-      matrix:
-        runner: [ubuntu, windows, macos]
-        target: [android, web] # On all platforms
-        include:
-          # Specify targets for each platform
-          - runner: ubuntu
-            target: linux
-          - runner: windows
-            target: windows
-          - runner: macos
-            target: macos
-          - runner: macos
-            target: ios
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          submodules: true
-
-      - name: Cache dependencies
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            target
-            ~/.pub-cache
-          key: >
-            ${{ matrix.runner }}-${{ matrix.target }}
-            ${{ hashFiles('**/Cargo.toml', '**/pubspec.yaml') }}
-          restore-keys: |
-            ${{ matrix.runner }}-${{ matrix.target }}
-            ${{ matrix.runner }}
-
-      - name: Setup Flutter SDK
-        uses: subosito/flutter-action@v2
-        with:
-          channel: "stable"
-
-      - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-
-      - name: Setup Ninja and GTK3 toolchain (Only Linux target)
-        if: matrix.target == 'linux'
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y ninja-build libgtk-3-dev
-
-      - name: Setup Java toolchain (Only Android target)
-        if: matrix.target == 'android'
-        uses: actions/setup-java@v5
-        with:
-          distribution: "zulu"
-          java-version: "17"
-
-      - name: Install the Python environment manager
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: false
-
-      - name: Install the CLI tool
-        run: cargo install rinf_cli
-
-      - name: Prepare a Flutter app for testing
-        run: uv run automate prepare-user-app
-
-      - name: Build the example app
-        if: matrix.target == 'linux'
-        working-directory: user_app/
-        run: flutter build linux --verbose
-
-      - name: Build the example app
-        if: matrix.target == 'android'
-        working-directory: user_app/
-        run: |
-          flutter build apk --verbose
-          flutter build appbundle --verbose
-
-      - name: Build the example app
-        if: matrix.target == 'windows'
-        working-directory: user_app/
-        run: |
-          # Clean CMake cache and build artifacts to prevent VS generator conflicts
-          $buildDir = "build/windows"
-          if (Test-Path $buildDir) {
-            Remove-Item "$buildDir/CMakeCache.txt" -Force -ErrorAction SilentlyContinue
-            Remove-Item "$buildDir/CMakeFiles" -Recurse -Force -ErrorAction SilentlyContinue
-            Remove-Item "$buildDir/*.cmake" -Force -ErrorAction SilentlyContinue
-            Remove-Item "$buildDir/cmake_install.cmake" -Force -ErrorAction SilentlyContinue
-          }
-          flutter build windows --verbose
-
-      - name: Build the example app
-        if: matrix.target == 'macos'
-        working-directory: user_app/
-        run: flutter build macos --verbose
-
-      - name: Build the example app
-        if: matrix.target == 'ios'
-        working-directory: user_app/
-        run: flutter build ios --verbose --no-codesign
-
-      - name: Build the example app
-        if: matrix.target == 'web'
-        working-directory: user_app/
-        run: |
-          rinf wasm --release
-          flutter build web --verbose
+1|# Verify that the documentation steps function as intended
+2|# when users utilize released versions
+3|# instead of the code from the repository.
+4|name: User App
+5|
+6|on:
+7|  workflow_dispatch:
+8|  schedule:
+9|    - cron: "*/30 * * * *"
+10|
+11|jobs:
+12|  build:
+13|    name: ${{ matrix.os }} / ${{ matrix.target }}
+14|    runs-on: ${{ matrix.os }}
+15|    strategy:
+16|      fail-fast: false # Important
+17|      matrix:
+18|        runner: [ubuntu, windows, macos]
+19|        target: [android, web] # On all platforms
+20|        include:
+21|          # Specify targets for each platform
+22|          - runner: ubuntu
+23|            target: linux
+24|          - runner: windows
+25|            target: windows
+26|          - runner: macos
+27|            target: macos
+28|          - runner: macos
+29|            target: ios
+30|
+31|    steps:
+32|      - name: Checkout repository
+33|        uses: actions/checkout@v6
+34|        with:
+35|          submodules: true
+36|
+37|      - name: Cache dependencies
+38|        uses: actions/cache@v5
+39|        with:
+40|          path: |
+41|            ~/.cargo/registry
+42|            target
+43|            ~/.pub-cache
+44|          key: >
+45|            ${{ matrix.os }}-${{ matrix.target }}
+46|            ${{ hashFiles('**/Cargo.toml', '**/pubspec.yaml') }}
+47|          restore-keys: |
+48|            ${{ matrix.os }}-${{ matrix.target }}
+49|            ${{ matrix.os }}
+50|
+51|      - name: Setup Flutter SDK
+52|        uses: subosito/flutter-action@v2
+53|        with:
+54|          channel: "stable"
+55|
+56|      - name: Setup Rust toolchain
+57|        uses: dtolnay/rust-toolchain@stable
+58|        with:
+59|          components: rustfmt
+60|
+61|      - name: Setup Ninja and GTK3 toolchain (Only Linux target)
+62|        if: matrix.target == 'linux'
+63|        run: |
+64|          sudo apt-get update -y
+65|          sudo apt-get install -y ninja-build libgtk-3-dev
+66|
+67|      - name: Setup Java toolchain (Only Android target)
+68|        if: matrix.target == 'android'
+69|        uses: actions/setup-java@v5
+70|        with:
+71|          distribution: "zulu"
+72|          java-version: "17"
+73|
+74|      - name: Install the Python environment manager
+75|        uses: astral-sh/setup-uv@v7
+76|        with:
+77|          enable-cache: false
+78|
+79|      - name: Install the CLI tool
+80|        run: cargo install rinf_cli
+81|
+82|      - name: Prepare a Flutter app for testing
+83|        run: uv run automate prepare-user-app
+84|
+85|      - name: Build the example app
+86|        if: matrix.target == 'linux'
+87|        working-directory: user_app/
+88|        run: flutter build linux --verbose
+89|
+90|      - name: Build the example app
+91|        if: matrix.target == 'android'
+92|        working-directory: user_app/
+93|        run: |
+94|          flutter build apk --verbose
+95|          flutter build appbundle --verbose
+96|
+97|      - name: Build the example app
+98|        if: matrix.target == 'windows'
+99|        working-directory: user_app/
+100|        run: |
+101|          # Clean CMake cache and build artifacts to prevent VS generator conflicts
+102|          $buildDir = "build/windows"
+103|          if (Test-Path $buildDir) {
+104|            Remove-Item "$buildDir/CMakeCache.txt" -Force -ErrorAction SilentlyContinue
+105|            Remove-Item "$buildDir/CMakeFiles" -Recurse -Force -ErrorAction SilentlyContinue
+106|            Remove-Item "$buildDir/*.cmake" -Force -ErrorAction SilentlyContinue
+107|            Remove-Item "$buildDir/cmake_install.cmake" -Force -ErrorAction SilentlyContinue
+108|          }
+109|          flutter build windows --verbose
+110|
+111|      - name: Build the example app
+112|        if: matrix.target == 'macos'
+113|        working-directory: user_app/
+114|        run: flutter build macos --verbose
+115|
+116|      - name: Build the example app
+117|        if: matrix.target == 'ios'
+118|        working-directory: user_app/
+119|        run: flutter build ios --verbose --no-codesign
+120|
+121|      - name: Build the example app
+122|        if: matrix.target == 'web'
+123|        working-directory: user_app/
+124|        run: |
+125|          rinf wasm --release
+126|          flutter build web --verbose
+127|

--- a/.github/workflows/user_app.yaml
+++ b/.github/workflows/user_app.yaml
@@ -106,9 +106,9 @@ jobs:
             Remove-Item "$buildDir/*.cmake" -Force -ErrorAction SilentlyContinue
             Remove-Item "$buildDir/cmake_install.cmake" -Force -ErrorAction SilentlyContinue
           }
-          # Specify Visual Studio 2022 generator explicitly to avoid generator conflicts
-          $env:CMAKE_GENERATOR="Visual Studio 17 2022"
-          flutter build windows --verbose
+          # Specify Visual Studio 2026 generator explicitly to avoid generator conflicts
+          $env:CMAKE_GENERATOR="Visual Studio 18 2026"
+          flutter build windows --verbose --cmake-define=CMAKE_GENERATOR="Visual Studio 18 2026"
 
       - name: Build the example app
         if: matrix.target == 'macos'

--- a/.github/workflows/user_app.yaml
+++ b/.github/workflows/user_app.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: ${{ matrix.runner }} / ${{ matrix.target }}
-    runs-on: ${{ matrix.runner }}-latest
+    runs-on: ${{ matrix.runner == "windows" && "windows-2025" || format("{0}-latest", matrix.runner) }}
     strategy:
       fail-fast: false # Important
       matrix:

--- a/.github/workflows/user_app.yaml
+++ b/.github/workflows/user_app.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: Build the example app
         if: matrix.target == 'windows'
         working-directory: user_app/
-        run: # Clean CMake cache and build artifacts to prevent VS generator conflicts
+        run: |
           $buildDir = "build/windows"
           if (Test-Path $buildDir) {
             Remove-Item "$buildDir/CMakeCache.txt" -Force -ErrorAction SilentlyContinue

--- a/.github/workflows/user_app.yaml
+++ b/.github/workflows/user_app.yaml
@@ -1,127 +1,125 @@
-1|# Verify that the documentation steps function as intended
-2|# when users utilize released versions
-3|# instead of the code from the repository.
-4|name: User App
-5|
-6|on:
-7|  workflow_dispatch:
-8|  schedule:
-9|    - cron: "*/30 * * * *"
-10|
-11|jobs:
-12|  build:
-13|    name: ${{ matrix.os }} / ${{ matrix.target }}
-14|    runs-on: ${{ matrix.os }}
-15|    strategy:
-16|      fail-fast: false # Important
-17|      matrix:
-18|        os: [ubuntu-latest, windows-2025, macos-latest]
-19|        target: [android, web] # On all platforms
-20|        include:
-21|          # Specify targets for each platform
-22|          - os: ubuntu-latest
-23|            target: linux
-24|          - os: windows-2025
-25|            target: windows
-26|          - os: macos-latest
-27|            target: macos
-28|          - os: macos-latest
-29|            target: ios
-30|
-31|    steps:
-32|      - name: Checkout repository
-33|        uses: actions/checkout@v6
-34|        with:
-35|          submodules: true
-36|
-37|      - name: Cache dependencies
-38|        uses: actions/cache@v5
-39|        with:
-40|          path: |
-41|            ~/.cargo/registry
-42|            target
-43|            ~/.pub-cache
-44|          key: >
-45|            ${{ matrix.os }}-${{ matrix.target }}
-46|            ${{ hashFiles('**/Cargo.toml', '**/pubspec.yaml') }}
-47|          restore-keys: |
-48|            ${{ matrix.os }}-${{ matrix.target }}
-49|            ${{ matrix.os }}
-50|
-51|      - name: Setup Flutter SDK
-52|        uses: subosito/flutter-action@v2
-53|        with:
-54|          channel: "stable"
-55|
-56|      - name: Setup Rust toolchain
-57|        uses: dtolnay/rust-toolchain@stable
-58|        with:
-59|          components: rustfmt
-60|
-61|      - name: Setup Ninja and GTK3 toolchain (Only Linux target)
-62|        if: matrix.target == 'linux'
-63|        run: |
-64|          sudo apt-get update -y
-65|          sudo apt-get install -y ninja-build libgtk-3-dev
-66|
-67|      - name: Setup Java toolchain (Only Android target)
-68|        if: matrix.target == 'android'
-69|        uses: actions/setup-java@v5
-70|        with:
-71|          distribution: "zulu"
-72|          java-version: "17"
-73|
-74|      - name: Install the Python environment manager
-75|        uses: astral-sh/setup-uv@v7
-76|        with:
-77|          enable-cache: false
-78|
-79|      - name: Install the CLI tool
-80|        run: cargo install rinf_cli
-81|
-82|      - name: Prepare a Flutter app for testing
-83|        run: uv run automate prepare-user-app
-84|
-85|      - name: Build the example app
-86|        if: matrix.target == 'linux'
-87|        working-directory: user_app/
-88|        run: flutter build linux --verbose
-89|
-90|      - name: Build the example app
-91|        if: matrix.target == 'android'
-92|        working-directory: user_app/
-93|        run: |
-94|          flutter build apk --verbose
-95|          flutter build appbundle --verbose
-96|
-97|      - name: Build the example app
-98|        if: matrix.target == 'windows'
-99|        working-directory: user_app/
-100|        run: |
-101|          # Clean CMake cache and build artifacts to prevent VS generator conflicts
-102|          $buildDir = "build/windows"
-103|          if (Test-Path $buildDir) {
-104|            Remove-Item "$buildDir/CMakeCache.txt" -Force -ErrorAction SilentlyContinue
-105|            Remove-Item "$buildDir/CMakeFiles" -Recurse -Force -ErrorAction SilentlyContinue
-106|            Remove-Item "$buildDir/*.cmake" -Force -ErrorAction SilentlyContinue
-107|            Remove-Item "$buildDir/cmake_install.cmake" -Force -ErrorAction SilentlyContinue
-108|          }
-109|          flutter build windows --verbose
-110|
-111|      - name: Build the example app
-112|        if: matrix.target == 'macos'
-113|        working-directory: user_app/
-114|        run: flutter build macos --verbose
-115|
-116|      - name: Build the example app
-117|        if: matrix.target == 'ios'
-118|        working-directory: user_app/
-119|        run: flutter build ios --verbose --no-codesign
-120|
-121|      - name: Build the example app
-122|        if: matrix.target == 'web'
-123|        working-directory: user_app/
-124|        run: |
-125|          rinf wasm --release
-126|          flutter build web --verbose
-127|
+# Verify that the documentation steps function as intended
+# when users utilize released versions
+# instead of the code from the repository.
+name: User App
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "*/30 * * * *"
+
+jobs:
+  build:
+    name: ${{ matrix.os }} / ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false # Important
+      matrix:
+        os: [ubuntu-latest, windows-2025, macos-latest]
+        target: [android, web] # On all platforms
+        include:
+          # Specify targets for each platform
+          - os: ubuntu-latest
+            target: linux
+          - os: windows-2025
+            target: windows
+          - os: macos-latest
+            target: macos
+          - os: macos-latest
+            target: ios
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Cache dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            target
+            ~/.pub-cache
+          key: >
+            ${{ matrix.os }}-${{ matrix.target }}
+            ${{ hashFiles('**/Cargo.toml', '**/pubspec.yaml') }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.target }}
+            ${{ matrix.os }}
+
+      - name: Setup Flutter SDK
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Setup Ninja and GTK3 toolchain (Only Linux target)
+        if: matrix.target == 'linux'
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y ninja-build libgtk-3-dev
+
+      - name: Setup Java toolchain (Only Android target)
+        if: matrix.target == 'android'
+        uses: actions/setup-java@v5
+        with:
+          distribution: "zulu"
+          java-version: "17"
+
+      - name: Install the Python environment manager
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: false
+
+      - name: Install the CLI tool
+        run: cargo install rinf_cli
+
+      - name: Prepare a Flutter app for testing
+        run: uv run automate prepare-user-app
+
+      - name: Build the example app
+        if: matrix.target == 'linux'
+        working-directory: user_app/
+        run: flutter build linux --verbose
+
+      - name: Build the example app
+        if: matrix.target == 'android'
+        working-directory: user_app/
+        run: |
+          flutter build apk --verbose
+          flutter build appbundle --verbose
+
+      - name: Build the example app
+        if: matrix.target == 'windows'
+        working-directory: user_app/
+        run: # Clean CMake cache and build artifacts to prevent VS generator conflicts
+          $buildDir = "build/windows"
+          if (Test-Path $buildDir) {
+            Remove-Item "$buildDir/CMakeCache.txt" -Force -ErrorAction SilentlyContinue
+            Remove-Item "$buildDir/CMakeFiles" -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item "$buildDir/*.cmake" -Force -ErrorAction SilentlyContinue
+            Remove-Item "$buildDir/cmake_install.cmake" -Force -ErrorAction SilentlyContinue
+          }
+          flutter build windows --verbose
+
+      - name: Build the example app
+        if: matrix.target == 'macos'
+        working-directory: user_app/
+        run: flutter build macos --verbose
+
+      - name: Build the example app
+        if: matrix.target == 'ios'
+        working-directory: user_app/
+        run: flutter build ios --verbose --no-codesign
+
+      - name: Build the example app
+        if: matrix.target == 'web'
+        working-directory: user_app/
+        run: |
+          rinf wasm --release
+          flutter build web --verbose

--- a/documentation/source/installing-toolchains.md
+++ b/documentation/source/installing-toolchains.md
@@ -24,7 +24,7 @@ Each Rinf version is compatible with the toolchain versions listed below and new
 
 | Rinf Version | Flutter/Dart Version | Rust Version |
 | ------------ | -------------------- | ------------ |
-| 8.9          | 3.24/3.5             | 1.88         |
+| 8.9          | 3.24/3.5             | 1.91         |
 | 8.8          | N/A                  | N/A          |
 | 8.7          | N/A                  | N/A          |
 | 8.6          | N/A                  | N/A          |

--- a/documentation/source/installing-toolchains.md
+++ b/documentation/source/installing-toolchains.md
@@ -24,7 +24,7 @@ Each Rinf version is compatible with the toolchain versions listed below and new
 
 | Rinf Version | Flutter/Dart Version | Rust Version |
 | ------------ | -------------------- | ------------ |
-| 8.9          | 3.24/3.5             | 1.91         |
+| 8.9          | 3.27/3.6             | 1.91         |
 | 8.8          | N/A                  | N/A          |
 | 8.7          | N/A                  | N/A          |
 | 8.6          | N/A                  | N/A          |

--- a/rust_crate_cli/src/tool/webassembly.rs
+++ b/rust_crate_cli/src/tool/webassembly.rs
@@ -63,11 +63,11 @@ fn install_wasm_toolchain() -> Result<(), SetupError> {
     .output()?
     .capture_err()?;
   Command::new("cargo")
-    .args(["install", "--locked", "wasm-pack"])
+    .args(["+nightly", "install", "--locked", "wasm-pack"])
     .output()?
     .capture_err()?;
   Command::new("cargo")
-    .args(["install", "--locked", "wasm-bindgen-cli"])
+    .args(["+nightly", "install", "--locked", "wasm-bindgen-cli"])
     .output()?
     .capture_err()?;
   Ok(())
@@ -109,6 +109,7 @@ fn compile_wasm(
         "-C link-arg=--shared-memory ",
         "-C link-arg=--max-memory=1073741824 ",
         "-C link-arg=--import-memory ",
+        "-C link-arg=--export=__heap_base ",
         "-C link-arg=--export=__wasm_init_tls ",
         "-C link-arg=--export=__tls_size ",
         "-C link-arg=--export=__tls_align ",


### PR DESCRIPTION
## Changes

- Upgrade CI workflows from Rust 1.88.0 to 1.91
- Update official documentation Rust version table

## Cause

`cargo-platform@0.3.3` requires Rust 1.91, causing `wasm-pack` build failures on Rust 1.88.0.

## Impact

- Fixes ubuntu/web, macos/web, windows/windows CI builds
- Rust 1.91 was released on 2025-10-30, a stable version